### PR TITLE
Improve installation with prerequisites guides

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -4,8 +4,6 @@
 
 ### Getting started
 * [Prerequisites](getting_started/prerequisites/README.md)
-  * [Linux](getting_started/prerequisites/linux.md)
-  * [macOS](getting_started/prerequisites/macos.md)
 * [Local installation](getting_started/installation.md)
 * [Production and Test servers](getting_started/servers.md)
 * [Recomendations](getting_started/recomendations.md)

--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -3,6 +3,9 @@
 * [Introduction](README.md)
 
 ### Getting started
+* [Prerequisites](getting_started/prerequisites/README.md)
+  * [Linux](getting_started/prerequisites/linux.md)
+  * [macOS](getting_started/prerequisites/macos.md)
 * [Local installation](getting_started/installation.md)
 * [Production and Test servers](getting_started/servers.md)
 * [Recomendations](getting_started/recomendations.md)

--- a/en/getting_started/installation.md
+++ b/en/getting_started/installation.md
@@ -1,37 +1,47 @@
 # Local installation
 
-Before installing Consul and having it up and running make sure you have [Ruby 2.3.2](https://www.ruby-lang.org/en/news/2016/11/15/ruby-2-3-2-released/) installed in your local environment.
+Before installing Consul and having it up and running make sure you all [prerequisites](prerequisites) installed.
 
 1. First, clone the [Consul Github repository](https://github.com/consul/consul/):
 
-  ```
+  ```bash
   git clone https://github.com/consul/consul.git
   ```
 
 2. Go to the project folder and install the gems stack using [Bundler](http://bundler.io/):
-  ```
+  
+  ```bash
   cd consul
   bundle install
   ```
 
 3. Copy the environment example configuration files inside new readable ones:
 
-  ```
+  ```bash
   cp config/database.yml.example config/database.yml
   cp config/secrets.yml.example config/secrets.yml
   ```
 
-4. Run the following [Rake tasks](https://github.com/ruby/rake) to fill your local database with the minimum data to run the application:
+  And setup database credentials with your `consul` user in your new `database.yml` file.
 
-  ```
+4. Run the following [Rake tasks](https://github.com/ruby/rake) to create and fill your local database with the minimum data to run the application:
+
+  ```bash
+  bin/rake db:create
   bin/rake db:setup
   bin/rake db:dev_seed
-  RAILS_ENV=test rake db:setup
+  RAILS_ENV=test bin/rake db:setup
   ```
 
-5. Now you have all set, run the application:
+5. Check everything is fine by running the test suite (beware it takes some long minutes):
 
+  ```bash
+  bundle exec rspec
   ```
+
+6. Now you have all set, run the application:
+
+  ```bash
   rails s
   ```
 

--- a/en/getting_started/prerequisites/README.md
+++ b/en/getting_started/prerequisites/README.md
@@ -1,0 +1,6 @@
+# Prerequisites Installation
+
+## [Linux](linux.html)
+
+## [macOS](macos.html)
+

--- a/en/getting_started/prerequisites/README.md
+++ b/en/getting_started/prerequisites/README.md
@@ -4,3 +4,4 @@
 
 ## [macOS](macos.html)
 
+## [Windows](https://translate.google.es/translate?sl=es&tl=en&js=y&prev=_t&hl=es&ie=UTF-8&u=http%3A%2F%2Fwikis.fdi.ucm.es%2FELP%2FTrabajo%3AC%25C3%25B3mo_colaborar_con_el_ayuntamiento&edit-text=&act=url)

--- a/en/getting_started/prerequisites/linux.md
+++ b/en/getting_started/prerequisites/linux.md
@@ -1,0 +1,95 @@
+# Configuration for development and test environments (GNU/Linux)
+
+## Git
+
+Git is officially maintained in Debian/Ubuntu:
+
+```
+sudo apt-get install git
+```
+
+## Ruby
+
+Ruby versions packaged in official repositories are not suitable to work with consul (at least Debian 7 and 8), so we'll have to install it manually.
+
+The preferred method is via rvm:
+
+(only the multi user option installs all dependencies automatically, as we use 'sudo'.)
+
+### As local user
+
+```
+curl -L https://get.rvm.io | bash -s stable
+```
+
+### For all system users
+
+```
+curl -L https://get.rvm.io | sudo bash -s stable
+```
+
+and then add your user to rvm group
+
+```
+sudo usermod -a -G rvm <user>
+```
+
+and finally, add rvm script source to user's bash (~/.bashrc) (this step it's only necessary if you still can't execute rvm command)
+
+```
+[[ -s /usr/local/rvm/scripts/rvm ]] && source /usr/local/rvm/scripts/rvm
+```
+
+with all this, you are suppose to be able to install a ruby version from rvm, as for example version 2.3.0:
+
+```
+sudo rvm install 2.3.0
+```
+
+## Bundler
+
+with
+
+```
+gem install bundler
+```
+
+or there is more methods [here](https://rvm.io/integration/bundler) that should be better as:
+
+```
+gem install rubygems-bundler
+```
+
+## PostgreSQL (>=9.4)
+
+PostgreSQL version 9.4 is not official in debian 7 (wheezy), in 8 it seems to be officially maintained.
+
+So you have to add a repository, the official postgresql works fine.
+
+Add the repository to apt, for example creating file */etc/apt/sources.list.d/pgdg.list* with:
+
+```
+deb http://apt.postgresql.org/pub/repos/apt/ wheezy-pgdg main
+```
+
+afterwards you'll have to download the key, and install it, by:
+
+```
+wget https://www.postgresql.org/media/keys/ACCC4CF8.asc
+apt-key add ACCC4CF8.asc
+```
+
+and install postgresql
+
+```
+apt-get update
+apt-get install postgresql-9.4
+```
+
+## Ghostscript
+
+```
+apt-get install ghostscript
+```
+
+> Now you're ready to go get Consul [installed](../installation.html)!!

--- a/en/getting_started/prerequisites/macos.md
+++ b/en/getting_started/prerequisites/macos.md
@@ -1,0 +1,107 @@
+# Configuration for development and test environments (macOS)
+
+## Homebrew
+
+Homebrew is a very popular package manager for OS X. It's advised to use it since it makes the installation of some of the dependencies much easier.
+
+You can find the installation instructions at: [brew.sh](http://brew.sh)
+
+## XCode and XCode Command Line Tools
+
+To install *git* you'll first need to install *Xcode* (download it from the Mac App Store) and its *Xcode Command Line Tools* (you can install them from the Xcode's app menu)
+
+## Git
+
+You can download git from: [git-scm.com/download/mac](https://git-scm.com/download/mac)
+
+## Ruby and rbenv
+
+OS X already comes with a preinstalled Ruby version, but it's quite old and we need a newer one (2.3.2). One of the multiple ways of installing Ruby in OS X is through *rbenv*. The installation instructions are in its GitHub repository and are pretty straight-forward:
+
+[github.com/rbenv/rbenv](https://github.com/rbenv/rbenv)
+
+## Bundler
+
+```
+gem install bundler
+```
+
+## PostgreSQL (>=9.4)
+
+```
+brew install postgres
+```
+
+Once installed, we need to *initialize* it:
+
+```
+initdb /usr/local/var/postgres
+```
+
+Now we're going to configure some things related to the *default user*. First we start postgres server with:
+
+```
+postgres -D /usr/local/var/postgres
+```
+
+At this point we're supposed to have postgres correctly installed and a default user will automatically be created (whose name will match our username). This user hasn't got a password yet.
+
+If we run `psql` we'll login into the postgres console with the default user. Probably it will fail since its required that a default database exists for that user. We can create it by typing:
+
+```
+createdb 'your_username'
+```
+
+If we run `psql` again we should now get access to postgres console. With `\du` you can see the current users list.
+
+In case you want to set a password for your user you can make it throught postgres console by:
+
+```
+ALTER USER your_username WITH PASSWORD 'your_password';
+```
+
+Now we'll create the *consul* user, the one the application is using. Run in postgres console:
+
+```
+CREATE ROLE consul WITH PASSWORD '000';
+ALTER ROLE consul WITH SUPERUSER;
+ALTER ROLE consul WITH login;
+```
+
+If at any point during PostgreSQL installation you feel you have messed things up, you can uninstall it and start again by running:
+
+```
+brew uninstall postgres
+```
+
+You'll have to delete also this directory (otherwise the new installation will generate conflicts, source: [gist.github.com/lxneng/741932](https://gist.github.com/lxneng/741932)):
+
+```
+rm -rf /usr/local/var/postgres
+```
+
+## Postgis
+
+```
+brew install postgis
+```
+
+## Ghostscript
+
+```
+brew install ghostscript
+```
+
+## PhantomJS
+
+```
+brew install phantomjs
+```
+
+## Imagemagick
+
+```
+brew install imagemagick
+```
+
+> Now you're ready to go get Consul [installed](../installation.html)!!

--- a/es/SUMMARY.md
+++ b/es/SUMMARY.md
@@ -4,8 +4,6 @@
 
 ### Primeros pasos
 * [Prerrequisitos](getting_started/prerequisites/README.md)
-  * [Linux](getting_started/prerequisites/linux.md)
-  * [macOS](getting_started/prerequisites/macos.md)
 * [Instalación local](getting_started/installation.md)
 * [Servidores de prueba y producción](getting_started/servers.md)
 * [Recomendaciones](getting_started/recomendations.md)

--- a/es/SUMMARY.md
+++ b/es/SUMMARY.md
@@ -3,6 +3,9 @@
 * [Introducción](README.md)
 
 ### Primeros pasos
+* [Prerrequisitos](getting_started/prerequisites/README.md)
+  * [Linux](getting_started/prerequisites/linux.md)
+  * [macOS](getting_started/prerequisites/macos.md)
 * [Instalación local](getting_started/installation.md)
 * [Servidores de prueba y producción](getting_started/servers.md)
 * [Recomendaciones](getting_started/recomendations.md)

--- a/es/getting_started/installation.md
+++ b/es/getting_started/installation.md
@@ -1,37 +1,47 @@
 # Instalación local
 
-Antes de instalar Consul y empezar a usarlo asegúrate de tener [Ruby 2.3.2](https://www.ruby-lang.org/en/news/2016/11/15/ruby-2-3-2-released/) instalado en tu entorno local.
+Antes de comenzar a instalar Consul, comprueba que tengas todos los [prerrequisitos](prerequisites) correctamente instalados.
 
 1. Primero, clona el [repositorio de Consul en Github](https://github.com/consul/consul/):
 
-  ```
+  ```bash
   git clone https://github.com/consul/consul.git
   ```
 
 2. Ve a la carpeta del proyecto e instala las gemas requeridas usando [Bundler](http://bundler.io/):
-  ```
+  
+  ```bash
   cd consul
   bundle install
   ```
 
 3. Copia los archivos de configuración de ejemplo del entorno dentro de unos nuevos válidos:
 
-  ```
+  ```bash
   cp config/database.yml.example config/database.yml
   cp config/secrets.yml.example config/secrets.yml
   ```
 
-4. Ejecuta las siguientes [tareas Rake](https://github.com/ruby/rake) para rellenar tu base de datos local con el mínimo de información necesaria para que la aplicación funcione correctamente:
+  Y configura los de tu usuario de base de datos `consul` en `database.yml`
 
-  ```
+4. Ejecuta las siguientes [tareas Rake](https://github.com/ruby/rake) para crear y rellenar tu base de datos local con el mínimo de información necesaria para que la aplicación funcione correctamente:
+
+  ```bash
+  bin/rake db:create
   bin/rake db:setup
   bin/rake db:dev_seed
-  RAILS_ENV=test rake db:setup
+  RAILS_ENV=test bin/rake db:setup
   ```
 
-5. Ahora que ya está todo listo puedes ejecutar la aplicación:
+5. Comprueba que todo funciona correctamente lanzando la suite de tests (ten en cuenta que tardará unos cuantos minutos):
 
+  ```bash
+  bundle exec rspec
   ```
+
+6. Ahora que ya está todo listo puedes ejecutar la aplicación:
+
+  ```bash
   rails s
   ```
 

--- a/es/getting_started/prerequisites/README.md
+++ b/es/getting_started/prerequisites/README.md
@@ -4,3 +4,5 @@
 
 ## [macOS](macos.html)
 
+## [Windows](http://wikis.fdi.ucm.es/ELP/Trabajo:C%C3%B3mo_colaborar_con_el_ayuntamiento)
+

--- a/es/getting_started/prerequisites/README.md
+++ b/es/getting_started/prerequisites/README.md
@@ -1,0 +1,6 @@
+# Instalación de Prerrequisitos
+
+## [Linux](linux.html)
+
+## [macOS](macos.html)
+

--- a/es/getting_started/prerequisites/linux.md
+++ b/es/getting_started/prerequisites/linux.md
@@ -1,0 +1,149 @@
+# Configuración para los entornos de desarrollo y pruebas  (GNU/Linux)
+
+## Git
+
+Git es mantenido oficialmente en Debian/Ubuntu:
+
+```
+sudo apt-get install git
+```
+
+## Ruby
+
+Las versiones de Ruby versions empaquetadas en repositorios oficiales no son aptas para trabajar con consul (al menos Debian 7 y 8), así que debemos instalar manualmente.
+
+El método recomendado es via rvm:
+
+(sólo la opción multiusuario instala todas las dependencias automáticamente, al usar 'sudo'.)
+
+### Como usuario local
+
+```
+curl -L https://get.rvm.io | bash -s stable
+```
+
+### Para todos los usuarios del sistema
+
+```
+curl -L https://get.rvm.io | sudo bash -s stable
+```
+
+añadismos nuestro usuario al grupo de rvm
+
+```
+sudo usermod -a -G rvm <user>
+```
+
+y finalmente, añadimos el script rvm a nuestro bash (~/.bashrc) (este paso sólo es necesario si no puedes ejecutar el comando rvm)
+
+```
+[[ -s /usr/local/rvm/scripts/rvm ]] && source /usr/local/rvm/scripts/rvm
+```
+
+con todo esto, deberías poder instalar la versión de ruby con rvm, por ejemplo la 2.3.2:
+
+```
+sudo rvm install 2.3.2
+```
+
+## Bundler
+
+usando
+
+```
+gem install bundler
+```
+
+hay varios métodos alternativos [aquí](https://rvm.io/integration/bundler) que podrían ser mejores como:
+
+```
+gem install rubygems-bundler
+```
+
+## PostgreSQL (>=9.4)
+
+La versión 9.4 de PostgreSQL no es oficial en Debian 7 (wheezy), pero en Debian 8 parece ser mantenida oficialmente.
+
+Así que debemos añadir el respositorio oficial de postgresql a apt, por ejemplo creando el fichero */etc/apt/sources.list.d/pgdg.list* con:
+
+```
+deb http://apt.postgresql.org/pub/repos/apt/ wheezy-pgdg main
+```
+
+después deberás descargar la key e instalarla:
+
+```
+wget https://www.postgresql.org/media/keys/ACCC4CF8.asc
+apt-key add ACCC4CF8.asc
+```
+
+y finalmente instalar postgresql
+
+```
+apt-get update
+apt-get install postgresql-9.4
+```
+
+## Ghostscript
+
+```
+apt-get install ghostscript
+```
+
+## Clonar el repositorio
+
+Ahora que ya tenemos todas las dependencias instalado podemos bajarnos el proyecto:
+
+```
+git clone https://github.com/consul/consul.git
+cd consul
+bundle install
+cp config/database.yml.example config/database.yml
+cp config/secrets.yml.example config/secrets.yml
+```
+
+Ahora copia en `database.yml` el usuario y la contraseña que pusiste para *consul*. Cuando ya lo hayas hecho:
+
+```
+rake db:create
+rake db:setup
+rake db:dev_seed
+RAILS_ENV=test bin/rake db:setup
+```
+
+Para ejecutar los tests:
+
+```
+bundle exec rspec
+```
+
+Quizás necesites crear un rol de superusuario en postgresql, y completar en el fichero*/config/database.yml* los campos 'user:' y 'password:'.
+
+Además, parece que postgresql usa un socket unix por defecto para las comunicaciones en local. Si te encuentras este problema creando la base de datos, cambia en */config/database.yml* la linea:
+
+```
+host: localhost
+```
+
+por:
+
+```
+host: /var/run/postgresql
+```
+
+Tras esto en el terminal ejecutaremos:
+
+```
+rake db:create
+rake db:setup
+rake db:dev_seed
+RAILS_ENV=test bin/rake db:setup
+```
+
+Y por último para comprobar que todo esta bien, lanza los tests:
+
+```
+bundle exec rspec
+```
+
+> Ya estás listo para [instalar Consul]](../installation.html)!!

--- a/es/getting_started/prerequisites/macos.md
+++ b/es/getting_started/prerequisites/macos.md
@@ -1,0 +1,136 @@
+# Configuración para los entornos de desarrollo y pruebas (Mac OS X)
+
+## Homebrew
+
+Homebrew es un gestor de paquetes para OS X muy popular. Es recomendable usarlo pues facilita enormemente la instalación de algunos de los paquetes necesarios.
+
+Puedes encontrar las instrucciones de instalación en: [brew.sh](http://brew.sh)
+
+## XCode y XCode Command Line Tools
+
+Para utilizar git necesitarás instalar *Xcode* (está en la Mac App Store) y las *Xcode Command Line Tools* (se instalan desde el menú de Xcode).
+
+## Git y Github
+
+Puedes descargar git desde: [git-scm.com/download/mac](https://git-scm.com/download/mac)
+
+## Ruby y rbenv
+
+OS X ya viene con una versión preinstalada de ruby, pero es bastante vieja y en nuestro caso no nos sirve. Una de las formas de instalar Ruby es a través de rbenv. Las instrucciones de instalación están en su GitHub y son bastante claras:
+
+[github.com/rbenv/rbenv](https://github.com/rbenv/rbenv)
+
+Después instala la versión de Ruby 2.3.2
+
+## Bundler
+
+```
+gem install bundler
+```
+
+## PostgreSQL (>=9.4)
+
+```
+brew install postgres
+```
+
+Una vez instalado es necesario *inicializar* la instalación:
+
+```
+initdb /usr/local/var/postgres
+```
+
+Ahora vamos a configurar algunos aspectos del usuario por defecto. Primero iniciamos el servidor de postgres con:
+
+```
+postgres -D /usr/local/var/postgres
+```
+
+Llegados a este punto se supone que tenemos postgres correctamente instalado y se nos habrá creado un usuario por defecto (cuyo nombre es nuestro nombre de usuario), y que (todavía) no tiene contraseña.
+
+Si ejecutamos `psql` accederemos a la consola de postgres con el usuario por defecto. Probablemente fallará porque es necesario que de antemano exista una base de datos por defecto para dicho usuario. Podemos crearla ejecutando sobre la terminal:
+
+```
+createdb 'tu_nombre_de_usuario'
+```
+
+Si ahora ejecutamos `psql` de nuevo deberíamos poder acceder correctamente a la consola de postgres. Si sobre la consola de postgres ejecutas `\du` puede ver la lista de usuarios actual.
+
+En el caso de que quieras asignarte una contraseña puedes hacerlo desde la consola de postgres con:
+
+```
+ALTER USER tu_nombre_usuario WITH PASSWORD 'tu_contraseña';
+```
+
+Ahora vamos a crear el usuario *consul*, que es el que utiliza la aplicación. Ejecuta sobre la consola de postgres:
+
+```
+CREATE ROLE consul WITH PASSWORD '000';
+ALTER ROLE consul WITH SUPERUSER;
+ALTER ROLE consul WITH login;
+```
+
+Si en algún momento durante la instalación de PostgreSQL y postgis sospechas que te has equivocado y deseas desinstalarlo y volver a empezar desde cero:
+
+```
+brew uninstall postgres
+```
+
+También tendrás que borrar el siguiente directorio para que no de conflictos cuando intentes volver a instalarlo (fuente: [gist.github.com/lxneng/741932](https://gist.github.com/lxneng/741932)):
+
+```
+rm -rf /usr/local/var/postgres
+```
+
+## Postgis
+
+```
+brew install postgis
+```
+
+## Ghostscript
+
+```
+brew install ghostscript
+```
+
+## PhantomJS
+
+```
+brew install phantomjs
+```
+
+## Imagemagick
+
+```
+brew install imagemagick
+```
+
+## Clonar el repositorio
+
+Ahora que ya tenemos todas las dependencias instalado podemos bajarnos el proyecto:
+
+```
+git clone https://github.com/consul/consul.git
+cd consul
+bundle install
+cp config/database.yml.example config/database.yml
+cp config/secrets.yml.example config/secrets.yml
+```
+
+Ahora copia en `database.yml` el usuario y la contraseña que pusiste para *consul*. Cuando ya lo hayas hecho:
+
+```
+rake db:create
+rake db:setup
+rake db:dev_seed
+RAILS_ENV=test bin/rake db:setup
+```
+
+Para ejecutar los tests:
+
+```
+bundle exec rspec
+```
+
+> Ya estás listo para [instalar Consul]](../installation.html)!!


### PR DESCRIPTION
Add prerequisites guides from consul code:
- https://github.com/consul/consul/blob/master/doc/en/dev_test_setup.md
- https://github.com/consul/consul/blob/master/doc/es/dev_test_setup.md

Plus new "run test suite" step on installation guide and some minor improvements (code block syntax to `bash`) for fun :)