### PR TITLE
Text & Translations and Images customization sections

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -13,7 +13,8 @@
 
 ### Customization
 * [Templating](customization/templating.md)
-* [Translations](customization/translations.md)
+* [Texts & Translations](customization/translations.md)
+* [Images](customization/images.md)
 * [Overwritting](customization/overwritting.md)
 * [Adding new features](customization/new_features.md)
 

--- a/en/customization/images.md
+++ b/en/customization/images.md
@@ -1,0 +1,11 @@
+# Images
+
+If you want to overwrite any image, firstly you need to findout the filename, and by defaul it will be located under `app/assets/images`. For example if you want to change the header logo (`app/assets/images/logo_header.png`) you must create another file with the exact same file name under `app/assets/images/custom` folder. The images and icons that you will most likely want to change are:
+
+* apple-touch-icon-200.png
+* icon_home.png
+* logo_email.png
+* logo_header.png
+* map.jpg
+* social_media_icon.png
+* social_media_icon_twitter.png

--- a/en/customization/translations.md
+++ b/en/customization/translations.md
@@ -2,4 +2,26 @@
 
 Currently Consul is translated totally or partially to multiple languages, check it's [Crowdin project](https://crowdin.com/project/consul)
 
-Please [join the translators](https://crwd.in/consul) to help cover the missing parts, or contact us through [consul's gitter](https://gitter.im/consul/consul) to become a Proofreader and validate translators contributions.
+Please [join the translators](https://crwd.in/consul) to add a new language or help complete existing ones, or contact us through [consul's gitter](https://gitter.im/consul/consul) to become a Proofreader and validate translators contributions.
+
+If you want to check translations of the user-facing texts you can find them organized in YML files under `config/locales/` folder. Take a look at the official Ruby on Rails [internationalization guide](http://guides.rubyonrails.org/i18n.html) to better understand the translations system.
+
+# Texts
+
+If you just want to change some of the existing texts, you can just drop your changes at the `config/locales/custom/` folder, we strongly recommend to include only those text that you want to change instead of a whole copy of the original file. For example if you want to customize the text "Ayuntamiento de Madrid, 2016" that appears on every page's footer, firstly you want to locate where it's used (`app/views/layouts/_footer.html.erb`), we can see code is:
+
+```ruby
+<%= t("layouts.footer.copyright", year: Time.current.year) %>
+```
+
+And that the text its located at the file `config/locales/es/general.yml` following this structure (we're only displaying in the following snippet the relevant parts):
+
+```yml
+es:
+  layouts:
+    footer:
+      copyright: Ayuntamiento de Madrid, %{year}
+
+```
+
+So in order to customize it, we would create a new file `config/locales/custom/es/general.yml` with just that content, and change "Ayuntamiento de Madrid" for our organization name. We strongly recommend to make copies from `config/locales/` and modify or delete the lines as needed to keep the indentation structure and avoid issues.

--- a/en/customization/translations.md
+++ b/en/customization/translations.md
@@ -1,1 +1,5 @@
 # Translations
+
+Currently Consul is translated totally or partially to multiple languages, check it's [Crowdin project](https://crowdin.com/project/consul)
+
+Please [join the translators](https://crwd.in/consul) to help cover the missing parts, or contact us through [consul's gitter](https://gitter.im/consul/consul) to become a Proofreader and validate translators contributions.

--- a/es/SUMMARY.md
+++ b/es/SUMMARY.md
@@ -13,7 +13,8 @@
 
 ### Personalización
 * [Interfaz y diseño](customization/templating.md)
-* [Idiomas](customization/translations.md)
+* [Textos & Traducciones](customization/translations.md)
+* [Imágenes](customization/images.md)
 * [Adaptar la aplicación](customization/overwritting.md)
 * [Añadir nuevas funcionalidades](customization/new_features.md)
 

--- a/es/customization/images.md
+++ b/es/customization/images.md
@@ -1,0 +1,11 @@
+# Imágenes
+
+Si quieres sobreescribir alguna imagen debes primero fijarte el nombre que tiene, por defecto se encuentran en `app/assets/images`. Por ejemplo si quieres modificar `app/assets/images/logo_header.png` debes poner otra con ese mismo nombre en el directorio `app/assets/images/custom`. Los iconos que seguramente quieras modificar son:
+
+* apple-touch-icon-200.png
+* icon_home.png
+* logo_email.png
+* logo_header.png
+* map.jpg
+* social_media_icon.png
+* social_media_icon_twitter.png

--- a/es/customization/translations.md
+++ b/es/customization/translations.md
@@ -1,1 +1,5 @@
 # Idiomas
+
+Actualmente Consul esta traducido total o parcialmente a multiples idiomas, visita el proyecto en [Crowdin](https://crowdin.com/project/consul)
+
+[Únete a los traductores](https://crwd.in/consul) para ayudar a cubrir nuevos idiomas o completar los actuales, o contacta con nosotros a través del [gitter de consul](https://gitter.im/consul/consul) para convertirte en Revisor y validar las contribuciones de los traductores.

--- a/es/customization/translations.md
+++ b/es/customization/translations.md
@@ -1,5 +1,27 @@
-# Idiomas
+# Traducciones
 
 Actualmente Consul esta traducido total o parcialmente a multiples idiomas, visita el proyecto en [Crowdin](https://crowdin.com/project/consul)
 
-[Únete a los traductores](https://crwd.in/consul) para ayudar a cubrir nuevos idiomas o completar los actuales, o contacta con nosotros a través del [gitter de consul](https://gitter.im/consul/consul) para convertirte en Revisor y validar las contribuciones de los traductores.
+[Únete a los traductores](https://crwd.in/consul) para ayudar añadir un nuevo lenguage o completar los existentes, o contacta con nosotros a través del [gitter de consul](https://gitter.im/consul/consul) para convertirte en Revisor y validar las contribuciones de los traductores.
+
+Si quieres ver las traducciones de los textos de la web, puedes encontrarlos en los ficheros formato YML disponibles en `config/locales/`. Puedes leer la [guía de internacionalización](http://guides.rubyonrails.org/i18n.html) de Ruby on Rails sobre como funciona este sistema.
+
+# Textos
+
+Las adaptaciones los debes poner en el directorio `config/locales/custom/`, recomendamos poner solo los textos que quieras personalizar. Por ejemplo si quieres personalizar el texto de "Ayuntamiento de Madrid, 2016" que se encuentra en el footer en todas las páginas, primero debemos ubicar en que plantilla se encuentra (`app/views/layouts/_footer.html.erb`), vemos que en el código pone lo siguiente:
+
+```ruby
+<%= t("layouts.footer.copyright", year: Time.current.year) %>
+```
+
+Y que en el fichero `config/locales/es/general.yml` sigue esta estructura (solo ponemos lo relevante para este caso):
+
+```yml
+es:
+  layouts:
+    footer:
+      copyright: Ayuntamiento de Madrid, %{year}
+
+```
+
+Si creamos el fichero `config/locales/custom/es/general.yml` y modificamos "Ayuntamiento de Madrid" por el nombre de la organización que se este haciendo la modificación. Recomendamos directamente copiar los ficheros `config/locales/` e ir revisando y corrigiendo las que querramos, borrando las líneas que no querramos traducir.


### PR DESCRIPTION
Add customization sections for:
- Images
- Text and Translations

People where sometimes confused about the double use if i18n (for translations but also for text customizations) that's reason behind the "Text and Translations" title