### PR TITLE
Add Node.js as prerequisite, installation instructions

### DIFF
--- a/en/README.md
+++ b/en/README.md
@@ -27,7 +27,7 @@ Development started on [2015 July 15th](https://github.com/consul/consul/commit/
 
 **NOTE**: For more detailed instructions check the [docs](https://consul_docs.gitbooks.io/docs/content/en/getting_started/prerequisites/)
 
-Prerequisites: install git, Ruby 2.3.2, bundler gem, and PostgreSQL (>=9.4).
+Prerequisites: install git, Ruby 2.3.2, bundler gem, Node.js and PostgreSQL (>=9.4).
 
 ```bash
 git clone https://github.com/consul/consul.git

--- a/en/getting_started/prerequisites/linux.md
+++ b/en/getting_started/prerequisites/linux.md
@@ -60,6 +60,20 @@ or there is more methods [here](https://rvm.io/integration/bundler) that should 
 gem install rubygems-bundler
 ```
 
+## Node.js
+
+To compile the assets, you'll need a JavaScript runtime. Node.js is the preferred option. As with Ruby, we don't recommend installing Node from your distro's repositories.
+
+To install it, you can use [n](https://github.com/tj/n)
+
+Run the following command on your terminal:
+
+```
+curl -L https://git.io/n-install | bash -s -- -y lts
+```
+
+And it will install the latest LTS (Long Term Support) Node version on your `$HOME` folder automatically (This makes use of [n-install](https://github.com/mklement0/n-install))
+
 ## PostgreSQL (>=9.4)
 
 PostgreSQL version 9.4 is not official in debian 7 (wheezy), in 8 it seems to be officially maintained.

--- a/en/getting_started/prerequisites/macos.md
+++ b/en/getting_started/prerequisites/macos.md
@@ -26,6 +26,20 @@ OS X already comes with a preinstalled Ruby version, but it's quite old and we n
 gem install bundler
 ```
 
+## Node.js
+
+To compile the assets, you'll need a JavaScript runtime. OS X comes with an integrated runtime called `Apple JavaScriptCore` but Node.js is the preferred option.
+
+To install it, you can use [n](https://github.com/tj/n)
+
+Run the following command on your terminal:
+
+```
+curl -L https://git.io/n-install | bash -s -- -y lts
+```
+
+And it will install the latest LTS (Long Term Support) Node version on your `$HOME` folder automatically (This makes use of [n-install](https://github.com/mklement0/n-install))
+
 ## PostgreSQL (>=9.4)
 
 ```

--- a/es/README.md
+++ b/es/README.md
@@ -27,7 +27,7 @@ El desarrollo de esta aplicación comenzó el [15 de Julio de 2015](https://gith
 
 **NOTA**: para unas instrucciones más detalladas consulta la [documentación](https://consul_docs.gitbooks.io/docs/content/es/getting_started/prerequisites/)
 
-Prerequisitos: tener instalado git, Ruby 2.3.2, la gema `bundler` y PostgreSQL (9.4 o superior).
+Prerequisitos: tener instalado git, Ruby 2.3.2, la gema `bundler`, Node.js y PostgreSQL (9.4 o superior).
 
 ```
 

--- a/es/getting_started/prerequisites/linux.md
+++ b/es/getting_started/prerequisites/linux.md
@@ -60,6 +60,20 @@ hay varios métodos alternativos [aquí](https://rvm.io/integration/bundler) que
 gem install rubygems-bundler
 ```
 
+## Node.js
+
+Para compilar los archivos estáticos (JS, CSS, imágenes, etc.), es necesario un _runtime_ de JavaScript. Node.js es la opción recomendada. Al igual que como ocurre con Ruby, no es recomendable instalar Node directamente de los repositorios de tu distribución Linux.
+
+Para instalar Node, puedes usar [n](https://github.com/tj/n)
+
+Ejecuta el siguiente comando en tu terminal:
+
+```
+curl -L https://git.io/n-install | bash -s -- -y lts
+```
+
+Y este instalará automáticamente la versión LTS (_Long Term Support_, inglés para "Soporte a largo plazo") más reciente de Node en tu directorio `$HOME` (Este comando hace uso de [n-install](https://github.com/mklement0/n-install))
+
 ## PostgreSQL (>=9.4)
 
 La versión 9.4 de PostgreSQL no es oficial en Debian 7 (wheezy), pero en Debian 8 parece ser mantenida oficialmente.

--- a/es/getting_started/prerequisites/macos.md
+++ b/es/getting_started/prerequisites/macos.md
@@ -28,6 +28,20 @@ Después instala la versión de Ruby 2.3.2
 gem install bundler
 ```
 
+## Node.js
+
+Para compilar los archivos estáticos (JS, CSS, imágenes, etc.), es necesario un _runtime_ de JavaScript. OS X viene con un _runtime_ integrado llamado `Apple JavaScriptCore` pero Node.js es la opción recomendada.
+
+Para instalar Node, puedes usar [n](https://github.com/tj/n)
+
+Ejecuta el siguiente comando en tu terminal:
+
+```
+curl -L https://git.io/n-install | bash -s -- -y lts
+```
+
+Y este instalará automáticamente la versión LTS (_Long Term Support_, inglés para "Soporte a largo plazo") más reciente de Node en tu directorio `$HOME` (Este comando hace uso de [n-install](https://github.com/mklement0/n-install))
+
 ## PostgreSQL (>=9.4)
 
 ```


### PR DESCRIPTION
# Where

* Related issue: #50 (Closes #50 once merged)
* Related PR: consul/consul#2486

# What

* Updates :gb:/:es: docs to include Node.js as a prerequisite for installing CONSUL and steps to install it as well on a development environment