### PR TITLE
Headless Chrome installation instructions

### DIFF
--- a/en/README.md
+++ b/en/README.md
@@ -47,7 +47,7 @@ Run the app locally:
 bin/rails s
 ```
 
-Prerequisites for testing: install PhantomJS >= 2.1.1
+Prerequisites for testing: install ChromeDriver >= 2.33
 
 Run the tests with:
 

--- a/en/getting_started/prerequisites/linux.md
+++ b/en/getting_started/prerequisites/linux.md
@@ -100,4 +100,63 @@ apt-get update
 apt-get install postgresql-9.4
 ```
 
+## ChromeDriver
+
+To run E2E integration tests, we use Selenium along with Headless Chrome.
+
+On Debian-based distros, the process to get ChromeDriver up and running is not as straightforward as on Mac OS.
+
+To get it working, first install the following packages:
+
+```bash
+sudo apt-get update && sudo apt-get install libxss1 libappindicator1 libindicator7 unzip
+```
+
+Then you need either Google Chrome or Chromium installed, both are valid.
+
+You can download the former from [here](https://www.google.com/chrome/index.html), while the latter can be installed with the following command:
+
+```bash
+sudo apt-get install chromium
+```
+
+You can now proceed to install ChromeDriver. First, check out its latest version [here](https://sites.google.com/a/chromium.org/chromedriver/)
+
+Download it the following way:
+
+```bash
+wget -N http://chromedriver.storage.googleapis.com/2.37/chromedriver_linux64.zip
+```
+
+Unzip it and make it executable like this:
+
+```bash
+unzip chromedriver_linux64.zip
+chmod +x chromedriver
+```
+
+Finally, add the binary to your `$PATH`:
+
+```bash
+sudo mv -f chromedriver /usr/local/share/chromedriver
+sudo ln -s /usr/local/share/chromedriver /usr/local/bin/chromedriver
+sudo ln -s /usr/local/share/chromedriver /usr/bin/chromedriver
+```
+
+Make sure everything's working as expected by running the following command:
+
+```bash
+chromedriver --version
+```
+
+You should receive an output with the latest version of ChromeDriver. If that's the case, you're good to go!
+
+If you happen to be on an Arch-based distro, installing `chromium` from the `extra` repo will do.
+
+There's also the option to only install ChromeDriver from AUR. If you're using `pacaur`, this will do:
+
+```bash
+pacaur -S chromedriver
+```
+
 > Now you're ready to go get Consul [installed](../installation.html)!!

--- a/en/getting_started/prerequisites/macos.md
+++ b/en/getting_started/prerequisites/macos.md
@@ -94,10 +94,10 @@ You'll have to delete also this directory (otherwise the new installation will g
 rm -rf /usr/local/var/postgres
 ```
 
-## PhantomJS
+## ChromeDriver
 
 ```
-brew install phantomjs
+brew install chromedriver
 ```
 
 ## Imagemagick

--- a/es/README.md
+++ b/es/README.md
@@ -48,7 +48,7 @@ Para ejecutar la aplicación en local:
 bin/rails s
 ```
 
-Prerequisitos para los tests: tener instalado PhantomJS >= 2.1.1
+Prerequisitos para los tests: tener instalado ChromeDriver >= 2.33
 
 Para ejecutar los tests:
 

--- a/es/getting_started/prerequisites/linux.md
+++ b/es/getting_started/prerequisites/linux.md
@@ -154,4 +154,63 @@ Y por último para comprobar que todo esta bien, lanza los tests:
 bundle exec rspec
 ```
 
+## ChromeDriver
+
+Para realizar pruebas de integración, usamos Selenium junto a Headless Chrome.
+
+En distribuciones basadas en Debian, el proceso de instalar ChromeDriver no es tan sencillo como en Mac OS.
+
+Para ello, primero instala los siguientes paquetes:
+
+```bash
+sudo apt-get update && sudo apt-get install libxss1 libappindicator1 libindicator7 unzip
+```
+
+Ahora necesitarás Google Chrome o Chromium. Ambas opciones son válidas.
+
+Puedes instalar el primero haciendo click [acá](https://www.google.com/chrome/index.html), mientras que el segundo puede ser instalado de la siguiente manera:
+
+```bash
+sudo apt-get install chromium
+```
+
+Ahora puedes instalar ChromeDriver. Primero, comprueba su última versión haciendo click [acá](https://sites.google.com/a/chromium.org/chromedriver/)
+
+Descárgalo ejecutando el siguiente comando:
+
+```bash
+wget -N http://chromedriver.storage.googleapis.com/2.37/chromedriver_linux64.zip
+```
+
+Descomprimelo y hazlo ejecutable:
+
+```bash
+unzip chromedriver_linux64.zip
+chmod +x chromedriver
+```
+
+Finalmente, añade el binario a tu `$PATH`:
+
+```bash
+sudo mv -f chromedriver /usr/local/share/chromedriver
+sudo ln -s /usr/local/share/chromedriver /usr/local/bin/chromedriver
+sudo ln -s /usr/local/share/chromedriver /usr/bin/chromedriver
+```
+
+Asegúrate de que todo funciona como es debido ejecutando el siguiente comando:
+
+```bash
+chromedriver --version
+```
+
+Deberías recibir un mensaje indicando la última versión de ChromeDriver. Si ese es el caso, está todo listo
+
+Si te encuentras usando una distro basada en Arch, instalando `chromium` desde el repositorio `extra` debería ser suficiente
+
+También tienes la opción de solo instalar ChromeDriver desde AUR. Si usas `pacaur`, ejecuta el siguiente comando:
+
+```bash
+pacaur -S chromedriver
+```
+
 > Ya estás listo para [instalar Consul](../installation.html)!!

--- a/es/getting_started/prerequisites/macos.md
+++ b/es/getting_started/prerequisites/macos.md
@@ -96,10 +96,10 @@ También tendrás que borrar el siguiente directorio para que no de conflictos c
 rm -rf /usr/local/var/postgres
 ```
 
-## PhantomJS
+## ChromeDriver
 
 ```
-brew install phantomjs
+brew install chromedriver
 ```
 
 ## Imagemagick


### PR DESCRIPTION
References
==========
* Related PRs: consul/consul#2534, AyuntamientoMadrid/consul#1387

Objectives
==========
Updated documentation to include ChromeDriver as a prerequisite for running tests as well as installation instructions for Mac OS and Linux in both :gb: and :es:
