### PR TITLE
Add documentation for production and other environments

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -11,6 +11,7 @@
 
 ### Installation
 * [Docker](getting_started/docker.md)
+* [Introduction](getting_started/introduction.md)
 * [Prerequisites](getting_started/prerequisites/README.md)
   * [Linux](getting_started/prerequisites/linux.md)
   * [macOS](getting_started/prerequisites/macos.md)

--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -7,10 +7,8 @@
 * [Configure your fork](forks/configuration.md)
 * [Keep your fork updated](forks/update.md)
 * [Communication](forks/communication.md)
-* [Manual deployment to Heroku](getting_started/deploying-on-heroku.md)
 
 ### Installation
-* [Docker](getting_started/docker.md)
 * [Introduction](getting_started/introduction.md)
 * [Prerequisites](getting_started/prerequisites/README.md)
   * [Linux](getting_started/prerequisites/linux.md)
@@ -18,7 +16,9 @@
   * [Windows](getting_started/prerequisites/windows.md)
 * [Local installation](getting_started/local_installation.md)
   * [Development Mail Server](getting_started/dev_mailserver.md)
-* [Production and Test servers](getting_started/servers.md)
+* [Production and Staging servers](getting_started/servers.md)
+* [Heroku](getting_started/deploying-on-heroku.md)
+* [Docker](getting_started/docker.md)
 
 ### Customization
 * [Introduction](customization/introduction.md)

--- a/en/getting_started/introduction.md
+++ b/en/getting_started/introduction.md
@@ -1,0 +1,11 @@
+# Introduction
+
+These are our recommendations for the different environments and purposes:
+
+- To setup CONSUL for a production environment we recommend using the [installer](https://github.com/consul/installer).
+
+- For developers working on a CONSUL fork we recommend using a UNIX based system (Linux or Mac) and installing CONSUL [locally system wide](https://consul_docs.gitbooks.io/docs/content/en/getting_started/prerequisites/).
+
+- If you run into problems configuring CONSUL locally system wide and would like to show CONSUL for demo purposes we recommend using [Docker](https://consul_docs.gitbooks.io/docs/en/getting_started/docker.html) in a local machine.
+
+- We also have a [Heroku guide](https://consul_docs.gitbooks.io/docs/content/en/getting_started/deploying-on-heroku.html) which can be used for demo purposes in a remote server.

--- a/en/getting_started/servers.md
+++ b/en/getting_started/servers.md
@@ -1,16 +1,16 @@
-# Production and Test servers
+# Production and Staging servers
 
 ## Recommended Minimum System Requirements:
 
 ### 1. Production Server:
-  - Distrubution: Ubuntu 16.04.3
+  - Distrubution: Ubuntu 16.04.X
   - RAM: 32GB
   - Processor: Quad core
   - Hard Drive: 20 GB
   - Database: Postgres
 
 ### 2. Staging Server:
-  - Distrubution: Ubuntu 16.04.3
+  - Distrubution: Ubuntu 16.04.X
   - RAM: 16GB
   - Processor: Dual core
   - Hard Drive: 20 GB

--- a/en/getting_started/servers.md
+++ b/en/getting_started/servers.md
@@ -17,3 +17,6 @@
   - Database: Postgres
 
 If your city has a population of over 1.000.000, consider balancing your load using 2-3 production servers and a separate server for the database.
+
+## Installation notes
+Check out the [installer's README](https://github.com/consul/installer)

--- a/es/SUMMARY.md
+++ b/es/SUMMARY.md
@@ -9,7 +9,6 @@
 * [Comunicación](forks/communication.md)
 
 ### Instalación
-* [Docker](getting_started/docker.md)
 * [Introducción](getting_started/introduction.md)
 * [Prerrequisitos](getting_started/prerequisites/README.md)
   * [Linux](getting_started/prerequisites/linux.md)
@@ -18,6 +17,7 @@
 * [Instalación local](getting_started/local_installation.md)
   * [Servidor local de correo](getting_started/dev_mailserver.md)
 * [Servidores de prueba y producción](getting_started/servers.md)
+* [Docker](getting_started/docker.md)
 
 ### Personalización
 * [Introducción](customization/README.md)

--- a/es/SUMMARY.md
+++ b/es/SUMMARY.md
@@ -10,6 +10,7 @@
 
 ### Instalación
 * [Docker](getting_started/docker.md)
+* [Introducción](getting_started/introduction.md)
 * [Prerrequisitos](getting_started/prerequisites/README.md)
   * [Linux](getting_started/prerequisites/linux.md)
   * [macOS](getting_started/prerequisites/macos.md)

--- a/es/SUMMARY.md
+++ b/es/SUMMARY.md
@@ -17,6 +17,7 @@
 * [Instalación local](getting_started/local_installation.md)
   * [Servidor local de correo](getting_started/dev_mailserver.md)
 * [Servidores de prueba y producción](getting_started/servers.md)
+* [Heroku](getting_started/deploying-on-heroku.md)
 * [Docker](getting_started/docker.md)
 
 ### Personalización

--- a/es/getting_started/introduction.md
+++ b/es/getting_started/introduction.md
@@ -4,8 +4,8 @@ Estas son nuestras recomendaciones para los diferentes entornos y propósitos:
 
 - Para configurar CONSUL para un entorno de producción, recomendamos utilizar el [instalador](https://github.com/consul/installer).
 
-- Para los programadores que trabajan en un entorno de desarrollo, recomendamos instalar CONSUL en un sistema basado en UNIX (Linux o Mac) e instalar CONSUL [en todo el sistema](https://consul_docs.gitbooks.io/docs/content/en/getting_started/prerequisites/).
+- Para los programadores que trabajan en un entorno de desarrollo, recomendamos instalar CONSUL en un sistema basado en UNIX (Linux o Mac) y hacer una [instalación local](https://consul_docs.gitbooks.io/docs/content/en/getting_started/prerequisites/) de CONSUL.
 
-- Si tiene problemas para configurar CONSUL localmente en todo el sistema y desea mostrar CONSUL para fines de demostración, le recomendamos que utilice [Docker](https://consul_docs.gitbooks.io/docs/en/getting_started/docker.html) en un local máquina.
+- Si tienes problemas para hacer una instalación local y deseas mostrar CONSUL para fines de demostración, te recomendamos que utilices [Docker](https://consul_docs.gitbooks.io/docs/en/getting_started/docker.html) en tu ordenador personal.
 
 - También tenemos una [Guía Heroku](https://consul_docs.gitbooks.io/docs/content/en/getting_started/deploying-on-heroku.html) que se puede utilizar para fines de demostración en un servidor remoto.

--- a/es/getting_started/introduction.md
+++ b/es/getting_started/introduction.md
@@ -1,0 +1,11 @@
+# Introducción
+
+Estas son nuestras recomendaciones para los diferentes entornos y propósitos:
+
+- Para configurar CONSUL para un entorno de producción, recomendamos utilizar el [instalador](https://github.com/consul/installer).
+
+- Para los programadores que trabajan en un entorno de desarrollo, recomendamos instalar CONSUL en un sistema basado en UNIX (Linux o Mac) e instalar CONSUL [en todo el sistema](https://consul_docs.gitbooks.io/docs/content/en/getting_started/prerequisites/).
+
+- Si tiene problemas para configurar CONSUL localmente en todo el sistema y desea mostrar CONSUL para fines de demostración, le recomendamos que utilice [Docker](https://consul_docs.gitbooks.io/docs/en/getting_started/docker.html) en un local máquina.
+
+- También tenemos una [Guía Heroku](https://consul_docs.gitbooks.io/docs/content/en/getting_started/deploying-on-heroku.html) que se puede utilizar para fines de demostración en un servidor remoto.

--- a/es/getting_started/servers.md
+++ b/es/getting_started/servers.md
@@ -1,16 +1,16 @@
 # Servidores de prueba y producción
 
-## Requisitos de Sistema mínimos recomendados:
+## Requisitos de sistema mínimos recomendados:
 
 ### 1. Production Server:
-  - Distrubution: Ubuntu 16.04.3
+  - Distrubution: Ubuntu 16.04.X
   - RAM: 32GB
   - Processor: Quad core
   - Hard Drive: 20 GB
   - Database: Postgres
 
 ### 2. Staging Server:
-  - Distrubution: Ubuntu 16.04.3
+  - Distrubution: Ubuntu 16.04.X
   - RAM: 16GB
   - Processor: Dual core
   - Hard Drive: 20 GB

--- a/es/getting_started/servers.md
+++ b/es/getting_started/servers.md
@@ -17,3 +17,6 @@
   - Database: Postgres
 
 Si tu ciudad tiene una población superior a 1.000.000, considera añadir un balanceador de carga y usar 2-3 servidores de producción, además de un servidor de base de datos dedicado.
+
+## Instrucciones de instalación
+Se encuentran en el [repositorio del instalador](https://github.com/consul/installer)


### PR DESCRIPTION
## References

**Issues**: 
- https://github.com/consul/installer/issues/74
- https://github.com/consul/docs/issues/25

## Objectives

- Add a link to the installer's documentation
- Add install recommendations for the different environments and purposes
- Make distribution version requeriments more flexible
- Restructure summary page
- Add link to heroku documentation for spanish

## Notes

The spanish documentation for heroku is in english, but I think it's better to have a link there until we translate it, than not having it 😌