### PR TITLE
Drop Windows support

### DIFF
--- a/en/installation/prerequisites.md
+++ b/en/installation/prerequisites.md
@@ -1,6 +1,6 @@
 # Prerequisites Installation
 
-* [Ubuntu](ubuntu.md)
-* [Debian](debian.md)
+* [Ubuntu Linux](ubuntu.md)
+* [Debian Linux](debian.md)
 * [MacOS](macos.md)
 * [Windows](windows.md)

--- a/en/installation/windows.md
+++ b/en/installation/windows.md
@@ -1,5 +1,3 @@
-# Configuration for development and test environments (Windows)
+# Windows
 
-[Check this third party guide](http://wikis.fdi.ucm.es/ELP/Trabajo:C%C3%B3mo_colaborar_con_el_ayuntamiento
-) (in Spanish [Google Translate english version](
-https://translate.google.es/translate?sl=es&tl=en&js=y&prev=_t&hl=es&ie=UTF-8&u=http%3A%2F%2Fwikis.fdi.ucm.es%2FELP%2FTrabajo%3AC%25C3%25B3mo_colaborar_con_el_ayuntamiento&edit-text=&act=url))
+Windows is not yet officially supported. Please install [Virtual Box](https://www.virtualbox.org/) to setup a virtual machine in [Linux](prerequisites).

--- a/es/installation/prerequisites.md
+++ b/es/installation/prerequisites.md
@@ -1,7 +1,7 @@
 # Instalación de Prerrequisitos
 
-* [Ubuntu](ubuntu.md)
-* [Debian](debian.md)
+* [Ubuntu Linux](ubuntu.md)
+* [Debian Linux](debian.md)
 * [MacOS](macos.md)
 * [Windows](windows.md)
 

--- a/es/installation/windows.md
+++ b/es/installation/windows.md
@@ -1,4 +1,3 @@
-# Configuración para los entornos de desarrollo y pruebas (Windows)
+# Windows
 
-[Guia de la Universidad Complutense](http://wikis.fdi.ucm.es/ELP/Trabajo:C%C3%B3mo_colaborar_con_el_ayuntamiento)
-
+De momento Windows no es un sistema operativo compatible. Por favor instale [Virtual Box](https://www.virtualbox.org/) para crear una máquina virtual en [Linux](prerequisites).


### PR DESCRIPTION
## Objectives

Drop Windows support

## Reasons
- Windows is a proprietary system, we try to support open source operating systems (apart from Mac which is awesome)
- There are many Ruby gems that are not fully supported in Windows.