### PR TITLE
Fix OAuth callback URLs

### DIFF
--- a/en/features/oauth.md
+++ b/en/features/oauth.md
@@ -12,7 +12,7 @@ They'll ask you for your CONSUL's auth URL, and as you can see running `rake rou
 user_omniauth_authorize GET|POST /users/auth/:provider(.:format)          users/omniauth_callbacks#passthru {:provider=>/twitter|facebook|google_oauth2/}
 ```
 
-So for example the URL for facebook application would be `yourdomain.com/users/auth/facebook.json`
+So for example the URL for facebook application would be `yourdomain.com/users/auth/facebook/callback`
 
 ## 3. Set key & secret values
 

--- a/es/features/oauth.md
+++ b/es/features/oauth.md
@@ -13,7 +13,7 @@ Te preguntarán por la URL de autenticación de tu instalación de CONSUL, y com
 user_omniauth_authorize GET|POST /users/auth/:provider(.:format)          users/omniauth_callbacks#passthru {:provider=>/twitter|facebook|google_oauth2/}
 ```
 
-Por ejemplo para facebook la URL sería `yourdomain.com/users/auth/facebook.json`
+Por ejemplo para facebook la URL sería `yourdomain.com/users/auth/facebook/callback`
 
 ## 3. Establece la clave y secreto
 


### PR DESCRIPTION
When configuring Oauth it turns out that the URL
```
yourdomain.com/users/auth/facebook.json
```
does not work.

Instead, we have to use:
``` 
yourdomain.com/users/auth/facebook/callback
```