### PR TITLE
Update installation instructions for Ruby 2.4.9

### DIFF
--- a/en/README.md
+++ b/en/README.md
@@ -27,7 +27,7 @@ Development started on [2015 July 15th](https://github.com/consul/consul/commit/
 
 **NOTE**: For more detailed instructions check the [docs](https://consul_docs.gitbooks.io/docs/content/en/getting_started/prerequisites/)
 
-Prerequisites: install git, Ruby 2.3.2, bundler gem, Node.js and PostgreSQL (>=9.4).
+Prerequisites: install git, Ruby 2.4.9, bundler gem, Node.js and PostgreSQL (>=9.4).
 
 ```bash
 git clone https://github.com/consul/consul.git

--- a/en/installation/debian.md
+++ b/en/installation/debian.md
@@ -62,10 +62,10 @@ and finally, reload .bashrc to be able to run RVM
 source /root/.bashrc
 ```
 
-with all this, you are suppose to be able to install a ruby version from rvm, as for example version 2.3.2:
+with all this, you are suppose to be able to install a ruby version from rvm, as for example version 2.4.9:
 
 ```
-rvm install 2.3.2
+rvm install 2.4.9
 ```
 
 ## Bundler

--- a/en/installation/deploying-on-heroku.md
+++ b/en/installation/deploying-on-heroku.md
@@ -119,7 +119,7 @@ As recommended by Heroku, you can add the gem rails\_12factor and specify the ve
 ```
 gem 'rails_12factor'
 
-ruby '2.3.2'
+ruby '2.4.9'
 ```
 
 in the file _Gemfile\_custom_. Don't forget to run

--- a/en/installation/macos.md
+++ b/en/installation/macos.md
@@ -16,7 +16,7 @@ You can download git from: [git-scm.com/download/mac](https://git-scm.com/downlo
 
 ## Ruby and rbenv
 
-OS X already comes with a preinstalled Ruby version, but it's quite old and we need a newer one (2.3.2). One of the multiple ways of installing Ruby in OS X is through *rbenv*. The installation instructions are in its GitHub repository and are pretty straight-forward:
+OS X already comes with a preinstalled Ruby version, but it's quite old and we need a newer one (2.4.9). One of the multiple ways of installing Ruby in OS X is through *rbenv*. The installation instructions are in its GitHub repository and are pretty straight-forward:
 
 [github.com/rbenv/rbenv](https://github.com/rbenv/rbenv)
 

--- a/en/installation/ubuntu.md
+++ b/en/installation/ubuntu.md
@@ -23,10 +23,8 @@ Ruby versions packaged in official repositories are not suitable to work with CO
 First, we need to install Ruby's development dependencies:
 
 ```bash
-sudo apt install libssl1.0-dev autoconf bison build-essential libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm5 libgdbm-dev
+sudo apt install libssl-dev autoconf bison build-essential libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm5 libgdbm-dev
 ```
-
-Note we're installing `libssl1.0-dev` instead of `libssl-dev`. That's because Ruby 2.3.2 (which CONSUL uses in version 0.19) is not compatible with OpenSSL 1.1.
 
 The next step is installing a Ruby version manager, like rbenv:
 
@@ -37,10 +35,10 @@ echo 'eval "$(rbenv init -)"' >> ~/.bashrc
 source ~/.bashrc
 ```
 
-Finally, install Ruby 2.3.2, which will take a few minutes:
+Finally, install Ruby 2.4.9, which will take a few minutes:
 
 ```bash
-rbenv install 2.3.2
+rbenv install 2.4.9
 ```
 
 ## Bundler
@@ -48,9 +46,9 @@ rbenv install 2.3.2
 Check we're using the Ruby version we've just installed:
 
 ```bash
-rbenv global 2.3.2
+rbenv global 2.4.9
 ruby -v
-=> ruby 2.3.2p217
+=> ruby 2.4.9p354
 ```
 
 And install Bundler with:

--- a/es/README.md
+++ b/es/README.md
@@ -27,7 +27,7 @@ El desarrollo de esta aplicación comenzó el [15 de Julio de 2015](https://gith
 
 **NOTA**: para unas instrucciones más detalladas consulta la [documentación](https://consul_docs.gitbooks.io/docs/content/es/getting_started/prerequisites/)
 
-Prerequisitos: tener instalado git, Ruby 2.3.2, la gema `bundler`, Node.js y PostgreSQL (9.4 o superior).
+Prerequisitos: tener instalado git, Ruby 2.4.9, la gema `bundler`, Node.js y PostgreSQL (9.4 o superior).
 
 ```
 

--- a/es/installation/debian.md
+++ b/es/installation/debian.md
@@ -63,10 +63,10 @@ por úlitmo, volvemos a cargar el .bashrc para poder ejecutar RVM
 source /root/.bashrc
 ```
 
-con todo esto, deberías poder instalar la versión de ruby con rvm, por ejemplo la 2.3.2:
+con todo esto, deberías poder instalar la versión de ruby con rvm, por ejemplo la 2.4.9:
 
 ```
-rvm install 2.3.2
+rvm install 2.4.9
 ```
 
 ## Bundler

--- a/es/installation/deploying-on-heroku.md
+++ b/es/installation/deploying-on-heroku.md
@@ -119,7 +119,7 @@ As recommended by Heroku, you can add the gem rails\_12factor and specify the ve
 ```
 gem 'rails_12factor'
 
-ruby '2.3.2'
+ruby '2.4.9'
 ```
 
 in the file _Gemfile\_custom_. Don't forget to run

--- a/es/installation/macos.md
+++ b/es/installation/macos.md
@@ -20,7 +20,7 @@ OS X ya viene con una versión preinstalada de ruby, pero es bastante vieja y en
 
 [github.com/rbenv/rbenv](https://github.com/rbenv/rbenv)
 
-Después instala la versión de Ruby 2.3.2
+Después instala la versión de Ruby 2.4.9
 
 ## Bundler
 

--- a/es/installation/ubuntu.md
+++ b/es/installation/ubuntu.md
@@ -23,10 +23,8 @@ Las versiones de Ruby versions empaquetadas en repositorios oficiales no son apt
 En primer lugar, necesitamos los siguiente paquetes para poder instalar Ruby:
 
 ```bash
-sudo apt install libssl1.0-dev autoconf bison build-essential libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm5 libgdbm-dev
+sudo apt install libssl-dev autoconf bison build-essential libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm5 libgdbm-dev
 ```
-
-Nótese que estamos instalando el paquete `libssl1.0-dev` en lugar de `libssl-dev`. Esto es debido a que Ruby 2.3.2 (versión que CONSUL 0.19 utiliza) no es compatible con OpenSSL 1.1.
 
 El siguiente paso es instalar un gestor de versiones de Ruby, como rbenv:
 
@@ -37,10 +35,10 @@ echo 'eval "$(rbenv init -)"' >> ~/.bashrc
 source ~/.bashrc
 ```
 
-Por último, para instalar Ruby 2.3.2 (proceso que llevará unos minutos):
+Por último, para instalar Ruby 2.4.9 (proceso que llevará unos minutos):
 
 ```bash
-rbenv install 2.3.2
+rbenv install 2.4.9
 ```
 
 ## Bundler
@@ -48,9 +46,9 @@ rbenv install 2.3.2
 Comprueba que estemos usando la versión de Ruby que acabamos de instalar:
 
 ```bash
-rbenv global 2.3.2
+rbenv global 2.4.9
 ruby -v
-=> ruby 2.3.2p217
+=> ruby 2.4.9p362
 ```
 
 E instala Bundle con:


### PR DESCRIPTION
## References

* CONSUL started using Ruby 2.4.6 in consul/consul#3627, and Ruby 2.4.9 in consul/consul#3785

## Objectives

* Use the same Ruby version CONSUL uses