### PR TITLE
Fix "connection" spelling

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -41,7 +41,7 @@
   * [OAuth](en/features/oauth.md)
   * [GraphQL](en/features/graphql.md)
   * [Recommendations](en/features/recommendations.md)
-  * [Configure Census Conexion](en/features/census_configuration.md)
+  * [Configure Census Connection](en/features/census_configuration.md)
   * [Local Census](en/features/local_census.md)
 
 * [Open Source project](en/open_source/open_source.md)

--- a/en/features/features.md
+++ b/en/features/features.md
@@ -3,5 +3,5 @@
 * [OAuth](oauth.md)
 * [GraphQL](graphql.md)
 * [Recommendations](recommendations.md)
-* [Configure Census Conexion](census_configuration.md)
+* [Configure Census Connection](census_configuration.md)
 * [Local Census](local_census.md)


### PR DESCRIPTION
## Objectives

Fix a couple of typos where the word "connection" was misspelled.