### PR TITLE
Improve GraphQL section

### DIFF
--- a/en/features/graphql.md
+++ b/en/features/graphql.md
@@ -1,5 +1,3 @@
-# GraphQL
-
 # API Documentation
 
 * [Characteristics](#characteristics)

--- a/es/features/graphql.md
+++ b/es/features/graphql.md
@@ -1,5 +1,3 @@
-# GraphQL
-
 # Documentación de la API
 
 * [Características](#características)

--- a/es/features/graphql.md
+++ b/es/features/graphql.md
@@ -1,24 +1,25 @@
 # Documentación de la API
 
-* [Características](#características)
+* [Características](#caracteristicas)
 * [GraphQL](#graphql)
 * [Haciendo peticiones a la API](#haciendo-peticiones-a-la-api)
   * [Clientes soportados](#clientes-soportados)
     * [GraphiQL](#graphiql)
     * [Postman](#postman)
-    * [Librerías HTTP](#librerías-http)
-* [Información disponible](#información-disponible)
+    * [Librerías HTTP](#librerias-http)
+* [Información disponible](#informacion-disponible)
 * [Ejemplos de consultas](#ejemplos-de-consultas)
-  * [Recuperar un único elemento de una colección](#recuperar-un-único-elemento-de-una-colección)
-  * [Recuperar una colección completa](#recuperar-una-colección-completa)
-    * [Paginación](#paginación)
-  * [Acceder a varios recursos en una única petición](#acceder-a-varios-recursos-en-una-única-petición)
+  * [Recuperar un único elemento de una colección](#recuperar-un-unico-elemento-de-una-coleccion)
+  * [Recuperar una colección completa](#recuperar-una-coleccion-completa)
+    * [Paginación](#paginacion)
+  * [Acceder a varios recursos en una única petición](#acceder-a-varios-recursos-en-una-unica-peticion)
 * [Limitaciones de seguridad](#limitaciones-de-seguridad)
   * [Ejemplo de consulta demasiado profunda](#ejemplo-de-consulta-demasiado-profunda)
   * [Ejemplo de consulta demasiado compleja](#ejemplo-de-consulta-demasiado-compleja)
-* [Ejemplos de código](#ejemplos-de-código)
+* [Ejemplos de código](#ejemplos-de-codigo)
 
-## Características
+<!-- ## Características -->
+<h2 id="caracteristicas">Características</h2>
 
 * API de sólo lectura
 * Acceso público, sin autenticación
@@ -111,7 +112,8 @@ La consulta debe estar ubicada en un documento JSON válido, como valor de la cl
 
 ![Postman POST](../../img/graphql/graphql-postman-post-body.png)
 
-#### Librerías HTTP
+<!-- #### Librerías HTTP -->
+<h4 id="librerias-http">Librerías HTTP</h4>
 
 Por supuesto es posible utilizar cualquier librería HTTP de lenguajes de programación.
 
@@ -120,7 +122,8 @@ Por supuesto es posible utilizar cualquier librería HTTP de lenguajes de progra
 `User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.115 Safari/537.36`
 
 
-## Información disponible
+<!-- ## Información disponible -->
+<h2 id="informacion-disponible">Información disponible</h2>
 
 El fichero [config/api.yml](../../config/api.yml) contiene una lista completa de los modelos (y sus campos) que están expuestos actualmente en la API.
 
@@ -139,8 +142,8 @@ La lista de modelos es la siguiente:
 
 ## Ejemplos de consultas
 
-### Recuperar un único elemento de una colección
-
+<!-- ### Recuperar un único elemento de una colección -->
+<h3 id="recuperar-un-unico-elemento-de-una-coleccion">Recuperar un único elemento de una colección</h3>
 ```
 {
   proposal(id: 2) {
@@ -165,7 +168,8 @@ Respuesta:
 }
 ```
 
-### Recuperar una colección completa
+<!-- ### Recuperar una colección completa -->
+<h3 id="recuperar-una-coleccion-completa">Recuperar una colección completa</h3>
 
 ```
 {
@@ -202,7 +206,8 @@ Respuesta:
 }
 ```
 
-#### Paginación
+<!-- #### Paginación -->
+<h4 id="paginacion">Paginación</h4>
 
 Actualmente el número máximo (y por defecto) de elementos que se devuelven en cada página está establecido a 25. Para poder navegar por las distintas páginas es necesario solicitar además información relativa al `endCursor`:
 
@@ -259,9 +264,10 @@ Para recuperar la siguiente página, hay que pasar como parámetro el cursor rec
 }
 ```
 
-### Acceder a varios recursos en una única petición
+<!-- ### Acceder a varios recursos en una única petición -->
+<h3 id="acceder-a-varios-recursos-en-una-unica-peticion">Acceder a varios recursos en una única petición</h3>
 
-Esta consulta solicita información relativa a varios modelos distintos en una única peticion: `Proposal`, `User`, `Geozone` y `Comment`:
+Esta consulta solicita información relativa a varios modelos distintos en una única petición: `Proposal`, `User`, `Geozone` y `Comment`:
 
 ```
 {
@@ -427,6 +433,7 @@ La respuesta:
 }
 ```
 
-## Ejemplos de código
+<!-- ## Ejemplos de código -->
+<h2 id="ejemplos-de-codigo">Ejemplos de código</h2>
 
 El directorio [doc/api/examples](https://github.com/consul/consul/tree/master/doc/api/examples/ruby) contiene ejemplos de código para acceder a la API.

--- a/es/features/graphql.md
+++ b/es/features/graphql.md
@@ -18,7 +18,6 @@
   * [Ejemplo de consulta demasiado compleja](#ejemplo-de-consulta-demasiado-compleja)
 * [Ejemplos de código](#ejemplos-de-codigo)
 
-<!-- ## Características -->
 <h2 id="caracteristicas">Características</h2>
 
 * API de sólo lectura
@@ -112,7 +111,6 @@ La consulta debe estar ubicada en un documento JSON válido, como valor de la cl
 
 ![Postman POST](../../img/graphql/graphql-postman-post-body.png)
 
-<!-- #### Librerías HTTP -->
 <h4 id="librerias-http">Librerías HTTP</h4>
 
 Por supuesto es posible utilizar cualquier librería HTTP de lenguajes de programación.
@@ -122,7 +120,6 @@ Por supuesto es posible utilizar cualquier librería HTTP de lenguajes de progra
 `User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.115 Safari/537.36`
 
 
-<!-- ## Información disponible -->
 <h2 id="informacion-disponible">Información disponible</h2>
 
 El fichero [config/api.yml](../../config/api.yml) contiene una lista completa de los modelos (y sus campos) que están expuestos actualmente en la API.
@@ -142,7 +139,6 @@ La lista de modelos es la siguiente:
 
 ## Ejemplos de consultas
 
-<!-- ### Recuperar un único elemento de una colección -->
 <h3 id="recuperar-un-unico-elemento-de-una-coleccion">Recuperar un único elemento de una colección</h3>
 ```
 {
@@ -168,7 +164,6 @@ Respuesta:
 }
 ```
 
-<!-- ### Recuperar una colección completa -->
 <h3 id="recuperar-una-coleccion-completa">Recuperar una colección completa</h3>
 
 ```
@@ -206,7 +201,6 @@ Respuesta:
 }
 ```
 
-<!-- #### Paginación -->
 <h4 id="paginacion">Paginación</h4>
 
 Actualmente el número máximo (y por defecto) de elementos que se devuelven en cada página está establecido a 25. Para poder navegar por las distintas páginas es necesario solicitar además información relativa al `endCursor`:
@@ -264,7 +258,6 @@ Para recuperar la siguiente página, hay que pasar como parámetro el cursor rec
 }
 ```
 
-<!-- ### Acceder a varios recursos en una única petición -->
 <h3 id="acceder-a-varios-recursos-en-una-unica-peticion">Acceder a varios recursos en una única petición</h3>
 
 Esta consulta solicita información relativa a varios modelos distintos en una única petición: `Proposal`, `User`, `Geozone` y `Comment`:
@@ -433,7 +426,6 @@ La respuesta:
 }
 ```
 
-<!-- ## Ejemplos de código -->
 <h2 id="ejemplos-de-codigo">Ejemplos de código</h2>
 
 El directorio [doc/api/examples](https://github.com/consul/consul/tree/master/doc/api/examples/ruby) contiene ejemplos de código para acceder a la API.

--- a/es/installation/docker.md
+++ b/es/installation/docker.md
@@ -46,7 +46,6 @@ sudo chmod +x /usr/local/bin/docker-compose
 
 Pendiente de ser completado... ¡Se agradecen las Contribuciones!
 
-<!-- ## Instalación -->
 <h2 id="instalacion">Instalación</h2>
 
 Clona el repositorio en tu ordenador y entra en el directorio:

--- a/es/installation/docker.md
+++ b/es/installation/docker.md
@@ -46,7 +46,8 @@ sudo chmod +x /usr/local/bin/docker-compose
 
 Pendiente de ser completado... ¡Se agradecen las Contribuciones!
 
-## Instalación
+<!-- ## Instalación -->
+<h2 id="instalacion">Instalación</h2>
 
 Clona el repositorio en tu ordenador y entra en el directorio:
 ```bash
@@ -113,7 +114,7 @@ Pendiente de ser completado... ¡Se agradecen las Contribuciones!
 
 
 ## ¿Tienes problemas?
-Ejecute los comandos en el **directorio de CONSUL**, para borrar todas las imágenes y contenedores anteriores del Docker de CONSUL. Luego, reinicie el [proceso de instalación](#instalación) de Docker:
+Ejecute los comandos en el **directorio de CONSUL**, para borrar todas las imágenes y contenedores anteriores del Docker de CONSUL. Luego, reinicie el [proceso de instalación](#instalacion) de Docker:
 
 1. Quitar todas las imágenes de CONSUL:
 ```bash


### PR DESCRIPTION
# Objectives
- Remove unnecessary title from GraphQL section.
In production unlike in local, a title is rendered that is defined in the SUMMARY.md, so it appears “GraphQL" twice as title and subtitle.
- FIx links with accent marks to sections

# Current Behavior
![Captura de pantalla 2019-12-04 a las 18 00 22](https://user-images.githubusercontent.com/16189/70164921-542e2c00-16c2-11ea-88e2-c0e4585c8cd3.png)



