### PR TITLE
Remove references to deprecated rake task

### DIFF
--- a/en/features/census_configuration.md
+++ b/en/features/census_configuration.md
@@ -13,8 +13,7 @@ In the section **Configuration > Global Configuration** a new tab **Remote Censu
 If we have the feature deactivated we will see an informative text that will indicate us how to activate it:
 ![Feature disabled](../../img/remote_census/feature-disabled-en.png)
 
-To activate the feature you must perform 2 steps:
-1. Execute the following command `bin/rake settings:create_remote_census_setting RAILS_ENV=production`
+To activate the feature you must follow the instructions of the previous image:
 1. Access through the administration panel of your application to the section **Settings > Features** and activate the module **Configure connection to the remote census (SOAP)** as shown below:
 ![Feature enabled](../../img/remote_census/feature-enabled-en.png)
 

--- a/es/features/census_configuration.md
+++ b/es/features/census_configuration.md
@@ -13,8 +13,7 @@ En la sección **Configuración > Configuración Global** se ha añadido una nue
 Si tenemos la funcionalidad desactivada veremos un texto informativo que nos indicará como activarla:
 ![Feature disabled](../../img/remote_census/feature-disabled-es.png)
 
-Para activar la funcionalidad deberá realizar 2 pasos:
-1. Ejecutar el siguiente comando `bin/rake settings:create_remote_census_setting RAILS_ENV=production`
+Para activar la funcionalidad deberá realizar seguir las instrucciones de la imagen anterior:
 1. Acceder a través del panel de administración de su aplicación a la sección **Configuración > Funcionalidades** y activar el módulo de **Configurar conexión al censo remoto (SOAP)** como se puede ver a continuación:
 ![Feature enabled](../../img/remote_census/feature-enabled-es.png)
 

--- a/es/features/census_configuration.md
+++ b/es/features/census_configuration.md
@@ -13,7 +13,7 @@ En la sección **Configuración > Configuración Global** se ha añadido una nue
 Si tenemos la funcionalidad desactivada veremos un texto informativo que nos indicará como activarla:
 ![Feature disabled](../../img/remote_census/feature-disabled-es.png)
 
-Para activar la funcionalidad deberá realizar seguir las instrucciones de la imagen anterior:
+Para activar la funcionalidad deberá seguir las instrucciones de la imagen anterior:
 1. Acceder a través del panel de administración de su aplicación a la sección **Configuración > Funcionalidades** y activar el módulo de **Configurar conexión al censo remoto (SOAP)** como se puede ver a continuación:
 ![Feature enabled](../../img/remote_census/feature-enabled-es.png)
 


### PR DESCRIPTION
## Description
Improve documentation of the connection to the remote census:
- Remove reference to a rake task that has become obsolete and is no longer in the repository. Right now the settings that were added in that rake task are found as "defaults" and are loaded every time we deploy the application.