### PR TITLE
Install Ruby based on CONSUL's .ruby-version

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Development started on [2015 July 15th](https://github.com/consul/consul/commit/
 
 **NOTE**: For more detailed instructions check the [docs](https://consul_docs.gitbooks.io/docs/content/en/getting_started/prerequisites/)
 
-Prerequisites: install git, Ruby 2.3.2, bundler gem, Node.js and PostgreSQL (>=9.4).
+Prerequisites: install git, Ruby (the version defined in the `.ruby-version` file in the CONSUL repository), the bundler gem, Node.js and PostgreSQL (>=9.4).
 
 ```bash
 git clone https://github.com/consul/consul.git

--- a/en/README.md
+++ b/en/README.md
@@ -27,7 +27,7 @@ Development started on [2015 July 15th](https://github.com/consul/consul/commit/
 
 **NOTE**: For more detailed instructions check the [docs](https://consul_docs.gitbooks.io/docs/content/en/getting_started/prerequisites/)
 
-Prerequisites: install git, Ruby 2.4.9, bundler gem, Node.js and PostgreSQL (>=9.4).
+Prerequisites: install git, Ruby (the version defined in the `.ruby-version` file in the CONSUL repository), the bundler gem, Node.js and PostgreSQL (>=9.4).
 
 ```bash
 git clone https://github.com/consul/consul.git

--- a/en/installation/debian.md
+++ b/en/installation/debian.md
@@ -38,11 +38,11 @@ Curl is officially maintained in Debian:
 apt-get install curl
 ```
 
-## Ruby
+## Ruby version manager
 
 Ruby versions packaged in official repositories are not suitable to work with consul, so we'll have to install it manually.
 
-The preferred method is via rvm:
+One possible tool is rvm:
 
 ### As a local user
 
@@ -62,20 +62,6 @@ and finally, reload .bashrc to be able to run RVM
 
 ```
 source ~/.bashrc
-```
-
-with all this, you are suppose to be able to install a ruby version from rvm, as for example version 2.4.9:
-
-```
-rvm install 2.4.9
-```
-
-## Bundler
-
-Install it with
-
-```
-gem install rubygems-bundler
 ```
 
 ## Node.js

--- a/en/installation/deploying-on-heroku.md
+++ b/en/installation/deploying-on-heroku.md
@@ -119,10 +119,10 @@ As recommended by Heroku, you can add the gem rails\_12factor and specify the ve
 ```
 gem 'rails_12factor'
 
-ruby '2.4.9'
+ruby 'x.y.z'
 ```
 
-in the file _Gemfile\_custom_. Don't forget to run
+in the file _Gemfile\_custom_, where `x.y.z` is the version defined in the `.ruby-version` file in the CONSUL repository. Don't forget to run
 
 ```
 bundle install

--- a/en/installation/local_installation.md
+++ b/en/installation/local_installation.md
@@ -27,7 +27,7 @@ ruby -v
 4. Install [Bundler](http://bundler.io/):
 
 ```bash
-gem install bundler
+gem install bundler --version 1.17.1
 ```
 
 5. Install the required gems using Bundler:

--- a/en/installation/local_installation.md
+++ b/en/installation/local_installation.md
@@ -45,7 +45,7 @@ cp config/secrets.yml.example config/secrets.yml
 
 And setup database credentials with your `consul` user in your new `database.yml` file.
 
-7. Run the following [Rake tasks](https://github.com/ruby/rake) to create and fill your local database with the minimum data to run the application:
+7. Run the following [Rake tasks](https://github.com/ruby/rake) to create and fill your local database with the minimum data needed to run the application:
 
 ```bash
 rake db:create

--- a/en/installation/local_installation.md
+++ b/en/installation/local_installation.md
@@ -2,20 +2,41 @@
 
 Before installing Consul and having it up and running make sure you all [prerequisites](prerequisites.md) installed.
 
-1. First, clone the [Consul Github repository](https://github.com/consul/consul/):
+1. First, clone the [Consul Github repository](https://github.com/consul/consul/) and enter the project folder:
 
 ```bash
 git clone https://github.com/consul/consul.git
+cd consul
 ```
 
-2. Go to the project folder and install the gems stack using [Bundler](http://bundler.io/):
+2. Install the Ruby version we need with your Ruby version manager. Here are some examples:
 
 ```bash
-cd consul
+rvm install `cat .ruby-version` # If you're using RVM
+rbenv install `cat .ruby-version` # If you're using rbenv
+asdf install ruby `cat .ruby-version` # If you're using asdf
+```
+
+3. Check we're using the Ruby version we've just installed:
+
+```bash
+ruby -v
+=> # (it should be the same as the version in the .ruby-version file)
+```
+
+4. Install [Bundler](http://bundler.io/):
+
+```bash
+gem install bundler
+```
+
+5. Install the required gems using Bundler:
+
+```bash
 bundle
 ```
 
-3. Copy the environment example configuration files inside new readable ones:
+6. Copy the environment example configuration files inside new readable ones:
 
 ```bash
 cp config/database.yml.example config/database.yml
@@ -24,7 +45,7 @@ cp config/secrets.yml.example config/secrets.yml
 
 And setup database credentials with your `consul` user in your new `database.yml` file.
 
-4. Run the following [Rake tasks](https://github.com/ruby/rake) to create and fill your local database with the minimum data to run the application:
+7. Run the following [Rake tasks](https://github.com/ruby/rake) to create and fill your local database with the minimum data to run the application:
 
 ```bash
 rake db:create
@@ -33,13 +54,13 @@ rake db:dev_seed
 rake db:test:prepare
 ```
 
-5. Check everything is fine by running the test suite (beware it might take more than an hour):
+8. Check everything is fine by running the test suite (beware it might take more than an hour):
 
 ```bash
 bin/rspec
 ```
 
-6. Now you have all set, run the application:
+9. Now you have all set, run the application:
 
 ```bash
 bin/rails s

--- a/en/installation/macos.md
+++ b/en/installation/macos.md
@@ -14,19 +14,11 @@ To install *git* you'll first need to install *Xcode* (download it from the Mac 
 
 You can download git from: [git-scm.com/download/mac](https://git-scm.com/download/mac)
 
-## Ruby and rbenv
+## Ruby version manager
 
-OS X already comes with a preinstalled Ruby version, but it's quite old and we need a newer one (2.4.9). One of the multiple ways of installing Ruby in OS X is through *rbenv*. The installation instructions are in its GitHub repository and are pretty straight-forward:
+OS X already comes with a preinstalled Ruby version, but it's quite old and we need a newer one. One of the multiple ways of installing Ruby in OS X is through *rbenv*. The installation instructions are in its GitHub repository and are pretty straight-forward:
 
 [github.com/rbenv/rbenv](https://github.com/rbenv/rbenv)
-
-Then install Ruby version 2.4.9
-
-## Bundler
-
-```
-gem install bundler
-```
 
 ## Node.js
 
@@ -108,4 +100,4 @@ brew install chromedriver
 brew install imagemagick
 ```
 
-Now that we have all the dependencies installed we can download the project: [installed](local_installation.md)
+Now that we have all the dependencies installed we can go ahead and [install Consul](local_installation.md).

--- a/en/installation/ubuntu.md
+++ b/en/installation/ubuntu.md
@@ -16,7 +16,7 @@ Git is officially maintained in Ubuntu:
 sudo apt install git
 ```
 
-## Ruby
+## Ruby version manager
 
 Ruby versions packaged in official repositories are not suitable to work with CONSUL, so we'll have to install it manually.
 
@@ -33,28 +33,6 @@ wget -q https://github.com/rbenv/rbenv-installer/raw/master/bin/rbenv-installer 
 echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bashrc
 echo 'eval "$(rbenv init -)"' >> ~/.bashrc
 source ~/.bashrc
-```
-
-Finally, install Ruby 2.4.9, which will take a few minutes:
-
-```bash
-rbenv install 2.4.9
-```
-
-## Bundler
-
-Check we're using the Ruby version we've just installed:
-
-```bash
-rbenv global 2.4.9
-ruby -v
-=> ruby 2.4.9p354
-```
-
-And install Bundler with:
-
-```bash
-gem install bundler
 ```
 
 ## Node.js

--- a/es/README.md
+++ b/es/README.md
@@ -27,7 +27,7 @@ El desarrollo de esta aplicación comenzó el [15 de Julio de 2015](https://gith
 
 **NOTA**: para unas instrucciones más detalladas consulta la [documentación](https://consul_docs.gitbooks.io/docs/content/es/getting_started/prerequisites/)
 
-Prerequisitos: tener instalado git, Ruby 2.4.9, la gema `bundler`, Node.js y PostgreSQL (9.4 o superior).
+Prerequisitos: tener instalado git, Ruby (versión definida en el fichero `.ruby-version` del repositorio de CONSUL), la gema `bundler`, Node.js y PostgreSQL (9.4 o superior).
 
 ```
 

--- a/es/installation/debian.md
+++ b/es/installation/debian.md
@@ -37,11 +37,11 @@ Curl es mantenido oficialmente en Debian:
 apt-get install curl
 ```
 
-## Ruby
+## Gestor de versiones de Ruby
 
 Las versiones de Ruby empaquetadas en repositorios oficiales no son aptas para trabajar con consul, así que debemos instalar manualmente.
 
-El método recomendado es via rvm:
+Una opción es utilizar rvm:
 
 ### Como usuario local
 
@@ -61,20 +61,6 @@ por úlitmo, volvemos a cargar el .bashrc para poder ejecutar RVM
 
 ```
 source ~/.bashrc
-```
-
-con todo esto, deberías poder instalar la versión de ruby con rvm, por ejemplo la 2.4.9:
-
-```
-rvm install 2.4.9
-```
-
-## Bundler
-
-lo instalamos usando
-
-```
-gem install rubygems-bundler
 ```
 
 ## Node.js

--- a/es/installation/deploying-on-heroku.md
+++ b/es/installation/deploying-on-heroku.md
@@ -119,10 +119,10 @@ As recommended by Heroku, you can add the gem rails\_12factor and specify the ve
 ```
 gem 'rails_12factor'
 
-ruby '2.4.9'
+ruby 'x.y.z'
 ```
 
-in the file _Gemfile\_custom_. Don't forget to run
+in the file _Gemfile\_custom_, where `x.y.z` is the version defined in the `.ruby-version` file in the CONSUL repository. Don't forget to run
 
 ```
 bundle install

--- a/es/installation/local_installation.md
+++ b/es/installation/local_installation.md
@@ -27,7 +27,7 @@ ruby -v
 4. Instala [Bundler](http://bundler.io/)
 
 ```bash
-gem install bundler
+gem install bundler --version 1.17.1
 ```
 
 5. Instala las gemas requeridas usando Bundler:

--- a/es/installation/local_installation.md
+++ b/es/installation/local_installation.md
@@ -2,20 +2,41 @@
 
 Antes de comenzar a instalar Consul, comprueba que tengas todos los [prerrequisitos](prerequisites.md) correctamente instalados.
 
-1. Primero, clona el [repositorio de Consul en Github](https://github.com/consul/consul/):
+1. Primero, clona el [repositorio de Consul en Github](https://github.com/consul/consul/) y ve a la carpeta del proyecto:
 
 ```bash
 git clone https://github.com/consul/consul.git
+cd consul/
 ```
 
-2. Ve a la carpeta del proyecto e instala las gemas requeridas usando [Bundler](http://bundler.io/):
+2. Instala la versión de Ruby necesaria con el gestor de versiones de tu elección. Algunos ejemplos:
 
 ```bash
-cd consul
+rvm install `cat .ruby-version` # Si usas RVM
+rbenv install `cat .ruby-version` # Si usas rbenv
+asdf install ruby `cat .ruby-version` # Si usas asdf
+```
+
+3. Comprueba que estemos usando la versión de Ruby que acabamos de instalar:
+
+```bash
+ruby -v
+=> # (debería aparecer la versión mencionada en el fichero .ruby-version)
+```
+
+4. Instala [Bundler](http://bundler.io/)
+
+```bash
+gem install bundler
+```
+
+5. Instala las gemas requeridas usando Bundler:
+
+```bash
 bundle
 ```
 
-3. Copia los archivos de configuración de ejemplo del entorno dentro de unos nuevos válidos:
+6. Copia los archivos de configuración de ejemplo del entorno dentro de unos nuevos válidos:
 
 ```bash
 cp config/database.yml.example config/database.yml
@@ -24,7 +45,7 @@ cp config/secrets.yml.example config/secrets.yml
 
 Y configura los de tu usuario de base de datos `consul` en `database.yml`
 
-4. Ejecuta las siguientes [tareas Rake](https://github.com/ruby/rake) para crear y rellenar tu base de datos local con el mínimo de información necesaria para que la aplicación funcione correctamente:
+7. Ejecuta las siguientes [tareas Rake](https://github.com/ruby/rake) para crear y rellenar tu base de datos local con el mínimo de información necesaria para que la aplicación funcione correctamente:
 
 ```bash
 rake db:create
@@ -33,13 +54,13 @@ rake db:dev_seed
 rake db:test:prepare
 ```
 
-5. Comprueba que todo funciona correctamente lanzando la suite de tests (ten en cuenta que podría tardar más de una hora):
+8. Comprueba que todo funciona correctamente lanzando la suite de tests (ten en cuenta que podría tardar más de una hora):
 
 ```bash
 bin/rspec
 ```
 
-6. Ahora que ya está todo listo puedes ejecutar la aplicación:
+9. Ahora que ya está todo listo puedes ejecutar la aplicación:
 
 ```bash
 bin/rails s

--- a/es/installation/macos.md
+++ b/es/installation/macos.md
@@ -14,13 +14,11 @@ Para utilizar git necesitarás instalar *Xcode* (está en la Mac App Store) y la
 
 Puedes descargar git desde: [git-scm.com/download/mac](https://git-scm.com/download/mac)
 
-## Ruby y rbenv
+## Gestor de versiones de Ruby
 
 OS X ya viene con una versión preinstalada de ruby, pero es bastante vieja y en nuestro caso no nos sirve. Una de las formas de instalar Ruby es a través de rbenv. Las instrucciones de instalación están en su GitHub y son bastante claras:
 
 [github.com/rbenv/rbenv](https://github.com/rbenv/rbenv)
-
-Después instala la versión de Ruby 2.4.9
 
 ## Bundler
 
@@ -108,4 +106,4 @@ brew install chromedriver
 brew install imagemagick
 ```
 
-Ahora que ya tenemos todas las dependencias instalado podemos bajarnos el proyecto: [instalar Consul](local_installation.md)
+Ahora que ya tenemos todas las dependencias instalado podemos proceder con la [instalación de Consul](local_installation.md)

--- a/es/installation/ubuntu.md
+++ b/es/installation/ubuntu.md
@@ -16,7 +16,7 @@ Git es mantenido oficialmente en Ubuntu:
 sudo apt install git
 ```
 
-## Ruby
+## Gestor de versiones de Ruby
 
 Las versiones de Ruby empaquetadas en repositorios oficiales no son aptas para trabajar con CONSUL, así que debemos instalarlo manualmente.
 
@@ -26,35 +26,13 @@ En primer lugar, necesitamos los siguiente paquetes para poder instalar Ruby:
 sudo apt install libssl-dev autoconf bison build-essential libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm5 libgdbm-dev
 ```
 
-El siguiente paso es instalar un gestor de versiones de Ruby, como rbenv:
+A continuación instalaremos un gestor de versiones de Ruby, como rbenv:
 
 ```bash
 wget -q https://github.com/rbenv/rbenv-installer/raw/master/bin/rbenv-installer -O- | bash
 echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bashrc
 echo 'eval "$(rbenv init -)"' >> ~/.bashrc
 source ~/.bashrc
-```
-
-Por último, para instalar Ruby 2.4.9 (proceso que llevará unos minutos):
-
-```bash
-rbenv install 2.4.9
-```
-
-## Bundler
-
-Comprueba que estemos usando la versión de Ruby que acabamos de instalar:
-
-```bash
-rbenv global 2.4.9
-ruby -v
-=> ruby 2.4.9p362
-```
-
-E instala Bundle con:
-
-```bash
-gem install bundler
 ```
 
 ## Node.js


### PR DESCRIPTION
## References

* We upgraded the documentation for Ruby 2.4 in pull request #84
* CONSUL started using Ruby 2.5.8 in consul/consul#3978
* Merging this pull request will make pull request #94 obsolete

## Objectives

Make the documentation to install Ruby work for every version of CONSUL, so we don't have to change the documentation every time we upgrade Ruby and users don't accidentally read the documentation for a version different than the one they're using.