### PR TITLE
Add documentation with recommendations for component customization

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -34,6 +34,7 @@
   * [Views & Styles](en/customization/views_and_styles.md)
   * [Javascript](en/customization/javascript.md)
   * [Models](en/customization/models.md)
+  * [Components](en/customization/components.md)
   * [Gems](en/customization/gems.md)
   * [Overwritting Application](en/customization/overwritting.md)
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -86,6 +86,7 @@
   * [Vistas & Estilos](es/customization/views_and_styles.md)
   * [Javascript](es/customization/javascript.md)
   * [Modelos](es/customization/models.md)
+  * [Componentes](es/customization/components.md)
   * [Gemas](es/customization/gems.md)
   * [Adaptar la aplicación](es/customization/overwritting.md)
 

--- a/en/customization/components.md
+++ b/en/customization/components.md
@@ -1,0 +1,25 @@
+# Components
+
+For components, customization can be used to change both the logic (included in a `.rb` file) and the view (included in a `.erb` file). If you only want to customize the logic for, let's say, the `Admin::TableActionsComponent`, create a file named `app/components/custom/admin/table_actions_component.rb` with the following content:
+
+```ruby
+require_dependency Rails.root.join("app", "components", "admin", "table_actions_component").to_s
+
+class Admin::TableActionsComponent
+  # Your custom logic here
+end
+```
+
+If, on the other hand, you also want to customize the view, you need a small modification. Instead of the previous code, use:
+
+```ruby
+class Admin::TableActionsComponent < ApplicationComponent; end
+
+require_dependency Rails.root.join("app", "components", "admin", "table_actions_component").to_s
+
+class Admin::TableActionsComponent
+  # Your custom logic here
+end
+```
+
+This will make the component use the view in `app/components/custom/admin/table_actions_component.html.erb`. You can create this file and customize it to your needs.

--- a/en/customization/customization.md
+++ b/en/customization/customization.md
@@ -6,5 +6,6 @@
 * [Views & Styles](views_and_styles.md)
 * [Javascript](javascript.md)
 * [Models](models.md)
+* [Components](components.md)
 * [Gems](gems.md)
 * [Overwritting Application](overwritting.md)

--- a/es/customization/components.md
+++ b/es/customization/components.md
@@ -1,0 +1,25 @@
+# Componentes
+
+En el caso de los componentes, la personalización puede utilizarse para cambiar tanto la lógica (incluida en un archivo `.rb`) como la vista (incluida en un archivo `.erb`). Si solo quieres personalizar la lógica, por ejemplo del componente `Admin::TableActionsComponent`, crea el archivo `app/components/custom/admin/table_actions_component.rb` con el siguiente contenido:
+
+```ruby
+require_dependency Rails.root.join("app", "components", "admin", "table_actions_component").to_s
+
+class Admin::TableActionsComponent
+  # Tu lógica personalizada aquí
+end
+```
+
+Si, por el contrario, también quieres personalizar la vista, necesitas una pequeña modificación. En lugar del código anterior, utiliza:
+
+```ruby
+class Admin::TableActionsComponent < ApplicationComponent; end
+
+require_dependency Rails.root.join("app", "components", "admin", "table_actions_component").to_s
+
+class Admin::TableActionsComponent
+  # Tu lógica personalizada aquí
+end
+```
+
+Esto hará que el componente utilice la vista en `app/components/custom/admin/table_actions_component.html.erb`. Puedes crear este archivo y personalizarlo según tus necesidades.

--- a/es/customization/customization.md
+++ b/es/customization/customization.md
@@ -6,5 +6,6 @@
 * [Vistas & Estilos](views_and_styles.md)
 * [Javascript](javascript.md)
 * [Modelos](models.md)
+* [Componentes](components.md)
 * [Gemas](gems.md)
 * [Adaptar la aplicación](overwritting.md)


### PR DESCRIPTION
## Objectives

Since we have added components in the application it was necessary to add to the documentation some recommendations to be able to customize the components.

## Visual Changes
- Add components section to summary:
![Captura de pantalla 2021-03-24 a las 12 14 14](https://user-images.githubusercontent.com/16189/112302217-1ed49580-8c9b-11eb-9626-d07a03e072a6.png)

- Add customize components documentation:
![Captura de pantalla 2021-03-24 a las 12 14 35](https://user-images.githubusercontent.com/16189/112302220-2005c280-8c9b-11eb-9551-47e3aee92683.png)


