### PR TITLE
Use the same URL to clone the repo everywhere

### DIFF
--- a/en/installation/docker.md
+++ b/en/installation/docker.md
@@ -64,7 +64,7 @@ If you encounter the "WSL 2 installation incomplete" error:
 Clone the repo on your computer and enter the folder:
 
 ```bash
-git clone git@github.com:consul/consul.git
+git clone https://github.com/consul/consul.git
 cd consul
 ```
 

--- a/es/installation/docker.md
+++ b/es/installation/docker.md
@@ -64,7 +64,7 @@ Si encuentras el error "WSL 2 installation incomplete":
 Clona el repositorio en tu ordenador y entra en el directorio:
 
 ```bash
-git clone git@github.com:consul/consul.git
+git clone https://github.com/consul/consul.git
 cd consul
 ```
 


### PR DESCRIPTION
## References

* Closes #44

## Objectives

* Make the documentation consistent
* Use a URL which makes it easier for everyone to clone the repository