### PR TITLE
Fix format typos in graphql guide

### DIFF
--- a/en/features/graphql.md
+++ b/en/features/graphql.md
@@ -119,7 +119,6 @@ Sure you can use any HTTP library available for most programming languages.
 
 `User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.115 Safari/537.36`
 
-
 ## Available information:
 
 The [config/api.yml](../../config/api.yml) file contains a complete list of all the models (and their attributes) which are currently being exposed in the API.

--- a/en/features/graphql.md
+++ b/en/features/graphql.md
@@ -261,7 +261,7 @@ To retrieve the next page, you have to pass as a parameter the cursor received i
 
 ### Accessing several resources in a single request
 
-This query requests information about several models in a single request: `Proposal`,` User`, `Geozone` and` Comment`:
+This query requests information about several models in a single request: `Proposal`, `User`, `Geozone` and `Comment`:
 
 ```
 {
@@ -338,7 +338,7 @@ The response will look something like this:
 
 ### Example of too complex query
 
-The main risk factor is when multiple collections of resources are requested in the same query. The maximum number of collections that can appear in the same query is limited to 2. The following query requests information from the `users`,` debates` and `proposals` collections, so it will be rejected:
+The main risk factor is when multiple collections of resources are requested in the same query. The maximum number of collections that can appear in the same query is limited to 2. The following query requests information from the `users`, `debates` and `proposals` collections, so it will be rejected:
 
 ```
 {
@@ -383,7 +383,7 @@ The response will look something like this:
 }
 ```
 
-However, it is possible to request information belonging to more than two models in a single query, as long as you do not try to access the entire collection. For example, the following query that accesses the `User`,` Proposal` and `Geozone` models is valid:
+However, it is possible to request information belonging to more than two models in a single query, as long as you do not try to access the entire collection. For example, the following query that accesses the `User`, `Proposal` and `Geozone` models is valid:
 
 ```
 {

--- a/en/features/graphql.md
+++ b/en/features/graphql.md
@@ -7,7 +7,7 @@
     * [GraphiQL](#graphiql)
     * [Postman](#postman)
     * [HTTP libraries](#http-libraries)
-* [Available information:](#available-information)
+* [Available information](#available-information)
 * [Examples of queries](#examples-of-queries)
   * [Request a single record from a collection](#request-a-single-record-from-a-collection)
   * [Request a complete collection](#request-a-complete-collection)
@@ -119,7 +119,7 @@ Sure you can use any HTTP library available for most programming languages.
 
 `User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.115 Safari/537.36`
 
-## Available information:
+## Available information
 
 The [config/api.yml](../../config/api.yml) file contains a complete list of all the models (and their attributes) which are currently being exposed in the API.
 

--- a/es/features/graphql.md
+++ b/es/features/graphql.md
@@ -119,7 +119,6 @@ Por supuesto es posible utilizar cualquier librería HTTP de lenguajes de progra
 
 `User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.115 Safari/537.36`
 
-
 <h2 id="informacion-disponible">Información disponible</h2>
 
 El fichero [config/api.yml](../../config/api.yml) contiene una lista completa de los modelos (y sus campos) que están expuestos actualmente en la API.
@@ -140,6 +139,7 @@ La lista de modelos es la siguiente:
 ## Ejemplos de consultas
 
 <h3 id="recuperar-un-unico-elemento-de-una-coleccion">Recuperar un único elemento de una colección</h3>
+
 ```
 {
   proposal(id: 2) {


### PR DESCRIPTION
## Objectives

* Fix texts of code starting with a space 
* Reduce the number of typos in the documentation