### PR TITLE
Update remote translation docs

### DIFF
--- a/en/customization/introduction.md
+++ b/en/customization/introduction.md
@@ -26,13 +26,13 @@ Also these are the files where you can apply some customization:
 
 The aim of this service is to be able to offer all the dynamic contents of the application (proposals, debates, budget investments and comments) in different languages without the need for a user or administrator to have created each one of their translations.
 
-When an user visit a page with a language where there is untranslated content, he will has a button to request the translation of all the content. This content will be sent to an automatic translator (in this case [Microsoft TranslatorText](https://azure.microsoft.com/en-us/services/cognitive-services/translator-text-api/)) and as soon as the response is obtained, all these translations will be available to any user.
+When a user visits a page with a language where there is untranslated content, they will have a button to request the translation of all the content. This content will be sent to an automatic translator (in this case [Microsoft TranslatorText](https://azure.microsoft.com/en-us/products/cognitive-services/translator/)) and as soon as the response is obtained, all these translations will be available to any user.
 
 #### Getting started
 In order to use this functionality, the following steps are necessary:
 1. Have an api key to connect to the translation service. For this we need an [Azure account](https://azure.microsoft.com/en-us/)
-1. Once you are logged into the Azure portal, subscribe to the Translator Text API in Microsoft Cognitive Service.
-1. Once you have subscribed to the Translator Text service, you will have access to 2 api keys in the section **RESOURCE MANAGEMENT > Keys** that will be necessary for the configuration of the translation service in your application.
+1. Once you are logged into the Azure portal, subscribe to the Translator in Cognitive Service.
+1. Once you have subscribed to the Translator Text service, you will have access to 2 api keys in the section **Resource Management > Keys and Endpoint** that will be necessary for the configuration of the translation service in your application.
 
 #### Configuration
 To activate the translation service in your application you must complete the following steps:
@@ -65,41 +65,28 @@ We attach some screenshots of how the application interacts with our users:
 
 
 #### Available languages for remote translation
-Currently these are all the [available languages](https://docs.microsoft.com/en-us/azure/cognitive-services/translator/quickstart-ruby-languages) in the translation service:
+Currently these are all the [available languages](https://api.cognitive.microsofttranslator.com/languages?api-version=3.0) in the translation service:
 ```yml
-["af", "ar", "bg", "bn", "bs", "ca", "cs", "cy", "da", "de", "el", "en", "es", "et", "fa", "fi", "fil", "fj", "fr", "he", "hi", "hr", "ht", "hu", "id", "is", "it", "ja", "ko", "lt", "lv", "mg", "ms", "mt", "mww", "nb", "nl", "otq", "pl", "pt", "ro", "ru", "sk", "sl", "sm", "sr-Cyrl", "sr-Latn", "sv", "sw", "ta", "te", "th", "tlh", "to", "tr", "ty", "uk", "ur", "vi", "yua", "yue", "zh-Hans", "zh-Hant"]
+["af", "am", "ar", "as", "az", "ba", "bg", "bn", "bo", "bs", "ca", "cs", "cy", "da", "de", "dv", "el", "en", "es", "et", "eu", "fa", "fi", "fil", "fj", "fo", "fr", "fr-CA", "ga", "gl", "gu", "ha", "he", "hi", "hr", "hsb", "ht", "hu", "hy", "id", "ig", "ikt", "is", "it", "iu", "iu-Latn", "ja", "ka", "kk", "km", "kmr", "kn", "ko", "ku", "ky", "ln", "lo", "lt", "lug", "lv", "lzh", "mg", "mi", "mk", "ml", "mn-Cyrl", "mn-Mong", "mr", "ms", "mt", "mww", "my", "nb", "ne", "nl", "nso", "nya", "or", "otq", "pa", "pl", "prs", "ps", "pt", "pt-PT", "ro", "ru", "run", "rw", "sk", "sl", "sm", "sn", "so", "sq", "sr-Cyrl", "sr-Latn", "st", "sv", "sw", "ta", "te", "th", "ti", "tk", "tlh-Latn", "tlh-Piqd", "tn", "to", "tr", "tt", "ty", "ug", "uk", "ur", "uz", "vi", "xh", "yo", "yua", "yue", "zh-Hans", "zh-Hant", "zu"]
 ```
-Of all the languages that Consul currently has defined(`available_locales`) in `config/application.rb` are not included in the above list and no translation service is offered for the following languages:
-```yml
-["val", "gl", "sq"]
-```
+Of all the languages that Consul currently has defined (`available_locales`) in `config/application.rb` the only one that is not listed above and therefore no translation service is offered is Valencian `["val"]`.
 
 #### Pricing
-The translation service used has the [pricing](https://azure.microsoft.com/en-us/pricing/details/cognitive-services/translator-text-api/) the most competitive.
-The price for each 1 Million characters translated is 8.43 € and there is no fixed cost per month.
-Google and DeepL have an approximate price of between 16.00 € and 20.00 € for each 1 million characters and a fixed monthly cost.
+The translation service used has the most competitive [pricing](https://azure.microsoft.com/en-us/pricing/details/cognitive-services/translator/).
+The price for each 1 Million characters translated is $10 and there is no fixed cost per month.
 
-Although technical measures have been taken to prevent misuse of this service, we recommend the creation of Alerts offered by Azure so that an Administrator can be notified in the event of detecting unusual use of the service.
+Although technical measures have been taken to prevent misuse of this service, we recommend the creation of Alerts offered by Azure so that an Administrator can be notified in the event of detecting unusual use of the service. This service has a cost of $0.10 per month.
 
 To create an Alert in Azure we must follow the following steps:
 1. Sign in to the **Azure Portal**.
-1. Register the resource providers needed to create Alerts
-  1. On the Azure portal menu, select **All services**.
-  1. In the **All services** box, enter **subscription**, and then select **Subscriptions**.
-  1. Select the subscription from the subscription list in order to view it.
-  1. Select **Resource providers** and check the list of available resource providers.
-  1. Among the resource providers we must select **microsoft.insights** and click on the button **Register**
-1. Create new alert rule:
-  1. On the Azure portal menu, select **All services**.
-  1. In the **All services** box, enter **subscription**, and then select **Subscriptions**.
-  1. Select the subscription from the subscription list in order to view it.
-  1. Select **Resources** and access the resource created from translations of the type **Cognitive Services**
-  1. In the **Monitoring** section select **Alerts** and we access **New alert rule**
-  1. Select the **Resource** that we want to alert on (if we have followed the previous steps it should already be selected)
-  1. Add a **Condition**. In this case the one we are interested is called `Characters Translated`. Once selected we must define the logic of the Alert to suit our needs. Ex: Fill "Operator" field with "Greater than" option, fill "Aggregation type" field with "Total" option and fill "Threshold value" field with the number of characters we consider should be translated before being notified. In this section you can also set the time period and frequency of evaluation.
+1. Access the **Translator** service created earlier.
+1. Go to **Monitoring > Alerts** in the side menu:
+  1. Go to **Create alert rule**.
+  1. In **Select a signal** select `Text Characters Translated`.
+  1. Once selected we must define the logic of the Alert to suit our needs. Ex: Fill "Operator" field with "Greater than" option, fill "Aggregation type" field with "Total" option and fill "Threshold value" field with the number of characters we consider should be translated before being notified. In this section you can also set the time period and frequency of evaluation.
   1. In order to be notified we have to create an **Action Group** and associate it with this Alert we're creating. To do this, access the button **Create** and fill out the form. As you can see there are different types of actions, we must select **Email/SMS/Push/Voice** and configure the option that we consider convenient according to our needs.
   1. Once this group of actions has been created, it is directly associated with the rule we are creating.
-  1. Finally, all you have to do is add a name and click on the **Create new alert rule**
+  1. Finally, all you have to do is add a name and click on the **Review + create**
 
 #### Add a new translation service
 If you want to integrate more translation services for any reason (new translation service appears, you want to change to include languages that are currently not supported, etc.) the code is ready to be added.

--- a/es/customization/introduction.md
+++ b/es/customization/introduction.md
@@ -26,13 +26,13 @@ Aparte de estos directorios también cuentas con ciertos ficheros para:
 
 Este servicio tiene como objetivo poder ofrecer todos los contenidos dinámicos de la aplicación (propuestas, debates, inversiones presupuestarias y comentarios) en diferentes idiomas sin la necesidad de que un usuario ó un administrador haya creado cada una de sus traducciones.
 
-Cuando un usuario accede a una pantalla con un idioma donde parte del contenido dinámico que esta visualizando no tiene traducciones, dispondrá de un botón para solicitar la traducción de todo el contenido. Este contenido se enviará a un traductor automático (en este caso [Microsoft TranslatorText](https://azure.microsoft.com/es-es/services/cognitive-services/translator-text-api/)) y en cuanto se obtenga la respuesta, todas estas traducciones estarán disponibles para cualquier usuario.
+Cuando un usuario accede a una pantalla con un idioma donde parte del contenido dinámico que esta visualizando no tiene traducciones, dispondrá de un botón para solicitar la traducción de todo el contenido. Este contenido se enviará a un traductor automático (en este caso [Microsoft TranslatorText](https://azure.microsoft.com/es-es/products/cognitive-services/translator/)) y en cuanto se obtenga la respuesta, todas estas traducciones estarán disponibles para cualquier usuario.
 
 #### Como empezar
 Para poder utilizar esta funcionalidad es necesario realizar los siguientes pasos:
 1. Disponer de una api key para conectarse con el servicio de traducción. Para ello necesitamos una [cuenta en Azure](https://azure.microsoft.com/es-es/)
-1. Una vez que haya iniciado sesión en el portal de Azure, subscríbase a Translator Text API en Microsoft Cognitive Service.
-1. Una vez subscrito al servicio de Translator Text, tendrá accesibles 2 api keys en la sección **RESOURCE MANAGEMENT > Keys** que serán necesarias para la configuración del servicio de traducciones en su aplicación.
+1. Una vez que haya iniciado sesión en el portal de Azure, subscríbase a Traductor en Cognitive Services.
+1. Una vez subscrito al servicio de Translator Text, tendrá accesibles 2 api keys en la sección **Administración de recursos > Claves y punto de conexión** que serán necesarias para la configuración del servicio de traducciones en su aplicación.
 
 #### Configuración
 Para activar el servicio de traducciones en su aplicación debe completar los siguientes pasos
@@ -65,41 +65,28 @@ Para aclarar el funcionamiento, se adjuntan unos pantallazos de como interactua 
 
 
 #### Idiomas disponibles para la traducción remota
-Actualmente estos son todos los [idiomas disponibles](https://docs.microsoft.com/es-es/azure/cognitive-services/translator/quickstart-ruby-languages) en el servicio de traducción:
+Actualmente estos son todos los [idiomas disponibles](https://api.cognitive.microsofttranslator.com/languages?api-version=3.0) en el servicio de traducción:
 ```yml
-["af", "ar", "bg", "bn", "bs", "ca", "cs", "cy", "da", "de", "el", "en", "es", "et", "fa", "fi", "fil", "fj", "fr", "he", "hi", "hr", "ht", "hu", "id", "is", "it", "ja", "ko", "lt", "lv", "mg", "ms", "mt", "mww", "nb", "nl", "otq", "pl", "pt", "ro", "ru", "sk", "sl", "sm", "sr-Cyrl", "sr-Latn", "sv", "sw", "ta", "te", "th", "tlh", "to", "tr", "ty", "uk", "ur", "vi", "yua", "yue", "zh-Hans", "zh-Hant"]
+["af", "am", "ar", "as", "az", "ba", "bg", "bn", "bo", "bs", "ca", "cs", "cy", "da", "de", "dv", "el", "en", "es", "et", "eu", "fa", "fi", "fil", "fj", "fo", "fr", "fr-CA", "ga", "gl", "gu", "ha", "he", "hi", "hr", "hsb", "ht", "hu", "hy", "id", "ig", "ikt", "is", "it", "iu", "iu-Latn", "ja", "ka", "kk", "km", "kmr", "kn", "ko", "ku", "ky", "ln", "lo", "lt", "lug", "lv", "lzh", "mg", "mi", "mk", "ml", "mn-Cyrl", "mn-Mong", "mr", "ms", "mt", "mww", "my", "nb", "ne", "nl", "nso", "nya", "or", "otq", "pa", "pl", "prs", "ps", "pt", "pt-PT", "ro", "ru", "run", "rw", "sk", "sl", "sm", "sn", "so", "sq", "sr-Cyrl", "sr-Latn", "st", "sv", "sw", "ta", "te", "th", "ti", "tk", "tlh-Latn", "tlh-Piqd", "tn", "to", "tr", "tt", "ty", "ug", "uk", "ur", "uz", "vi", "xh", "yo", "yua", "yue", "zh-Hans", "zh-Hant", "zu"]
 ```
-De todos los idiomas que actualmente tiene Consul definidos(`available_locales`) en `config/application.rb` no están incluidos en la lista anterior y por lo tanto no se ofrece servicio de traducción para los siguientes idiomas:
-```yml
-["val", "gl", "sq"]
-```
+De todos los idiomas que actualmente tiene Consul definidos (`available_locales`) en `config/application.rb` el único que no está en la lista anterior y por lo tanto no se ofrece servicio de traducción es el valenciano `["val"]`.
 
 #### Costes
-El servicio de traducción utilizado tiene los [precios](https://azure.microsoft.com/es-es/pricing/details/cognitive-services/translator-text-api/) más competitivos del mercado.
-El precio por cada 1 Millón de caracteres traducidos asciende a 8,43 € y sin ningún tipo de coste fijo al mes.
-La competencia Google y DeepL tienen un precio aproximado de entre 16,00 € y 20,00 € por cada 1 Millón de caracteres más un fijo mensual.
+El servicio de traducción utilizado tiene los [precios](https://azure.microsoft.com/es-es/pricing/details/cognitive-services/translator/) más competitivos del mercado.
+El precio por cada 1 Millón de caracteres traducidos asciende a 10 $ y sin ningún tipo de coste fijo al mes.
 
-Aunque se han tomado medidas técnicas para evitar un mal uso de este servicio, recomendamos la creación de Alertas que ofrece Azure para que un Administrador pueda ser notificado en el caso de detectar un uso fuera de lo común del servicio.
+Aunque se han tomado medidas técnicas para evitar un mal uso de este servicio, recomendamos la creación de Alertas que ofrece Azure para que un Administrador pueda ser notificado en el caso de detectar un uso fuera de lo común del servicio. Este servicio tiene un coste de 0,10 $ al mes.
 
 Para crear una Alerta en Azure debemos seguir los siguientes pasos:
 1. Inicie sesión en **Azure Portal**.
-1. Registrar los proveedores de recursos necesarios para crear Alertas
-  1. En el menú de Azure Portal, seleccione **Todos los servicios**.
-  1. En el cuadro **Todos los servicios**, escriba **suscripción** y, a continuación, seleccione **Suscripciones**.
-  1. Seleccione la suscripción en la lista de suscripciones para verla.
-  1. Seleccione **Proveedores de recursos** y consulte la lista de proveedores de recursos disponibles.
-  1. Entre los proveedores de recursos debemos seleccionar **microsoft.insights** y clicar sobre el botón **Registrarse**
-1. Crear nueva regla de Alerta:
-  1. En el menú de Azure Portal, seleccione **Todos los servicios**.
-  1. En el cuadro **Todos los servicios**, escriba **suscripción** y, a continuación, seleccione **Suscripciones**.
-  1. Seleccione la suscripción en la lista de suscripciones para verla.
-  1. Seleccione **Recursos** y acceda al recurso creado de traducciones del tipo **Cognitive Services**
-  1. En la sección **Supervisión** seleccionamos **Alertas** y accedemos a **Nueva regla de alertas**
-  1. Seleccionamos el **Recurso** sobre el cual queremos añadir la Alerta (si hemos seguido los pasos anteriores ya debería estar seleccionado)
-  1. Agregamos una **Condición**. En este caso la que nos interesa tiene como nombre `Characters Translated`. Una vez seleccionada debemos definir la lógica de la Alerta para que se ajuste a nuestras necesidades. Ej: Rellene el campo "Operador" con el valor "Mayor que", rellene el campo "Tipo de Agregación" con el valor "Total" y por último rellene el campo "Valor del umbral" por el número de caracteres que consideramos que deben traducirse antes de ser notificados. En esta sección también se puede configurar el periodo de tiempo y la frecuencia de evaluación.
-  1. Para poder ser notificados tenemos que crear un **Action Group** y asociarla a esta Alerta que estamos creando. Para ello accedemos al botón de **Crear** y rellenamos el formulario. Como se puede observar hay diferentes tipos de acciones, debemos seleccionar **Correo electrónico/SMS/Insertar/Voz** y configurar la opción que consideremos conveniente según nuestras necesidades.
+1. Accede al servicio **Traductor** creado anteriormente.
+1. Accede en el menu lateral a **Supervisión > Alertas**:
+  1. Accedemos a **Crear regla de alertas**
+  1. En **Selección de una señal** seleccionamos `Text Characters Translated`
+  1. Una vez seleccionada debemos definir la lógica de la Alerta para que se ajuste a nuestras necesidades. Ej: Rellene el campo "Operador" con el valor "Mayor que", rellene el campo "Tipo de Agregación" con el valor "Total" y por último rellene el campo "Valor del umbral" por el número de caracteres que consideramos que deben traducirse antes de ser notificados. En esta sección también se puede configurar el periodo de tiempo y la frecuencia de evaluación.
+  1. Para poder ser notificados tenemos que crear un **Grupo de Acciones** y asociarla a esta Alerta que estamos creando. Para ello accedemos al botón de **Crear** y rellenamos el formulario. Como se puede observar hay diferentes tipos de acciones, debemos seleccionar **Correo electrónico/SMS/Insertar/Voz** y configurar la opción que consideremos conveniente según nuestras necesidades.
   1. Una vez creado este grupo de acciones, ya queda directamente asociado a la regla que estamos creando.
-  1. Por último ya solo queda añadir un nombre y clicar sobre el botón **Crear regla de alertas**
+  1. Por último ya solo queda añadir un nombre y clicar sobre el botón **Revisar y crear**
 
 #### Añadir un nuevo servicio de traducción
 En el caso de que se quieran integrar más servicios de traducción por cualquier motivo (aparece un nuevo en el mercado más competitivo, se quiere cambiar para contemplar los idiomas que actualmente no tienen soporte, etc) se ha dejado preparado el código para poder añadirlo con las mínimas modificaciones posibles.


### PR DESCRIPTION
## References
Use Bing Translator instead of TranslatorText [#5089](https://github.com/consul/consul/pull/5089)

# Objectives
Due to the change of the translator-text gem to the bing_translator gem, the documentation has been reviewed and changes have been detected in the links, prices and azure administration panel.

We removed the Google and DeepL prices, since we will not be reviewing the prices of the different providers and they may be out of date.